### PR TITLE
feat(resume): auto-compile from GitHub .tex via latexonline.cc

### DIFF
--- a/src/components/sections/Contact/Contact.test.tsx
+++ b/src/components/sections/Contact/Contact.test.tsx
@@ -31,7 +31,8 @@ describe('Contact Section', () => {
   it('has view resume button with correct href', () => {
     render(<Contact />)
     const resumeBtn = screen.getByText(/view resume/i)
-    expect(resumeBtn).toHaveAttribute('href', '/WillChen_Resume.pdf')
+    const href = resumeBtn.getAttribute('href') || ''
+    expect(href).toContain('latexonline.cc/compile')
     expect(resumeBtn).toHaveAttribute('target', '_blank')
     expect(resumeBtn).toHaveAttribute('rel', 'noopener noreferrer')
   })

--- a/src/components/sections/Hero/Hero.test.tsx
+++ b/src/components/sections/Hero/Hero.test.tsx
@@ -72,9 +72,12 @@ describe('Hero Section', () => {
       await user.click(viewProjectsBtn)
       expect(mockScrollTo).toHaveBeenCalled()
 
-      // Test View Resume button opens the static PDF
+      // Test View Resume button opens the auto-compiled resume URL
       await user.click(viewResumeBtn)
-      expect(mockOpen).toHaveBeenCalledWith('/WillChen_Resume.pdf', '_blank')
+      expect(mockOpen).toHaveBeenCalledWith(
+        expect.stringContaining('latexonline.cc/compile'),
+        '_blank'
+      )
     })
   })
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,7 +9,12 @@ export const SITE_CONFIG = {
   creator: '@willchennn'
 } as const
 
-export const RESUME_PATH = '/WillChen_Resume.pdf'
+// Compiled on-the-fly from the Overleaf-synced .tex in the resume repo.
+// Every push to github.com/smallchungus/WillChen_Resume03_09_DE triggers
+// a fresh compile on next request.
+// Fallback: '/WillChen_Resume.pdf' (static copy in public/) if latexonline.cc is unavailable.
+export const RESUME_PATH =
+  'https://latexonline.cc/compile?git=https://github.com/smallchungus/WillChen_Resume03_09_DE&target=main.tex'
 
 export const CONTACT_INFO = {
   email: 'wchen1396@gmail.com',


### PR DESCRIPTION
## Summary
Resume link now auto-updates whenever you push to Overleaf/GitHub.

- Changes \`RESUME_PATH\` from \`/WillChen_Resume.pdf\` (static file) to \`https://latexonline.cc/compile?git=https://github.com/smallchungus/WillChen_Resume03_09_DE&target=main.tex\`
- latexonline.cc fetches the .tex from GitHub on every request, compiles it, and serves the fresh PDF
- Tests updated to assert the URL contains \`latexonline.cc/compile\` (loose match, since the full URL is long)
- \`public/WillChen_Resume.pdf\` stays in the repo as a manual fallback — revert the constant to \`/WillChen_Resume.pdf\` if latexonline.cc is ever down

## How it works
1. Edit \`.tex\` in Overleaf
2. Overleaf syncs to GitHub (your setup)
3. Next time the resume link is clicked, latexonline.cc fetches the latest .tex and compiles
4. Zero manual steps, zero redeploy

## Tradeoff
External service dependency. latexonline.cc is a free service run by an individual — generally reliable but could go down. Fallback noted above.

## Test plan
- [x] 132/132 tests pass
- [x] Type-check passes
- [x] Build succeeds
- [ ] Click resume button on preview deploy; verify PDF loads

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing resume access now depends on an external compilation service, so availability/latency or URL behavior changes could break the resume link despite minimal code churn.
> 
> **Overview**
> Updates `RESUME_PATH` to point at a `latexonline.cc/compile` URL that fetches/compiles the resume from a GitHub LaTeX repo instead of serving the local `/WillChen_Resume.pdf`.
> 
> Adjusts `Hero` and `Contact` section tests to assert the resume link/open target contains `latexonline.cc/compile` (looser matching for the longer dynamic URL) and documents the static PDF as a manual fallback in comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa61d6008c7087d16fbfe60b2a65c6e14394eae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->