### PR TITLE
feat(content): sync portfolio to Data Engineer resume narrative

### DIFF
--- a/docs/superpowers/specs/2026-04-16-resume-url-consolidation-design.md
+++ b/docs/superpowers/specs/2026-04-16-resume-url-consolidation-design.md
@@ -25,7 +25,7 @@ Update workflow after this change: edit `.tex` in Overleaf → download compiled
 
 ## Non-goals
 
-- **Content sync.** Updating Notion or [src/content/fallback-content.json](../../../src/content/fallback-content.json) to reflect the new Data Engineer resume (Newark NJ, Viatris, Isaac Lab, Distributed Task Queue project, etc.) is a separate spec.
+- **Content sync.** Updating Notion or [src/content/fallback-content.json](../../../src/content/fallback-content.json) to reflect the new Data Engineer resume (Newark NJ, Viatrie, Isaac Lab, Distributed Task Queue project, etc.) is a separate spec.
 - **LaTeX CI automation.** Auto-compiling `.tex` → PDF on push to the resume repo was considered and rejected as over-engineered for a resume updated a handful of times a year. Manual download + commit is the accepted workflow.
 - **SEO, UI refresh, other improvements** flagged in conversation. Separate specs.
 

--- a/scripts/setup-notion-database.ts
+++ b/scripts/setup-notion-database.ts
@@ -94,7 +94,7 @@ const CONTENT_ROWS = [
       'Datadog',
       'GitHub Actions'
     ],
-    company: 'Viatris (Federal Contract)',
+    company: 'Viatrie (Federal Contract)',
     duration: 'April 2024 - April 2026'
   },
   {

--- a/scripts/setup-notion-database.ts
+++ b/scripts/setup-notion-database.ts
@@ -9,74 +9,69 @@ const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID!
 
 const notion = new Client({ auth: NOTION_API_KEY })
 
-// Content to populate - Updated with latest resume
+// Content to populate - Sourced from WillChen_Resume03_09_DE (Data Engineer variant)
 const CONTENT_ROWS = [
   // Hero
   {
     title: 'Hero',
     section: 'hero',
     order: 1,
-    description: 'Python, Java, Go, TypeScript, React',
-    tags: ['Software Engineer', 'Full-Stack Developer', 'MS Analytics @ Georgia Tech'],
-    impact: 'Building scalable applications and solving complex problems with modern technologies. Passionate about clean code, performance, and exceptional user experiences.'
+    description: 'Python, Go, SQL, AWS, Docker, Kubernetes',
+    tags: ['Software Engineer', 'Data Engineer', 'MS CS @ ASU'],
+    impact:
+      "Building production-grade ETL pipelines and distributed systems. Passionate about data infrastructure, cloud-native tooling, and reliable engineering at scale."
   },
-  // Skills
+  // Skills (grouped from resume's "Languages & Databases" and "Cloud & Tools" sections)
   {
     title: 'Languages',
     section: 'skills',
     order: 10,
-    tags: ['Python', 'Java', 'Go', 'JavaScript', 'TypeScript', 'SQL']
+    tags: ['Python', 'Go', 'SQL', 'JavaScript']
   },
   {
-    title: 'Backend',
+    title: 'Databases',
     section: 'skills',
     order: 11,
-    tags: ['Spring Boot', 'Node.js', 'PostgreSQL', 'Redis', 'Apache Kafka']
-  },
-  {
-    title: 'Frontend',
-    section: 'skills',
-    order: 12,
-    tags: ['React', 'Redux', 'Tailwind CSS', 'HTML/CSS']
+    tags: ['PostgreSQL', 'Redis', 'Amazon Redshift']
   },
   {
     title: 'Cloud & DevOps',
     section: 'skills',
-    order: 13,
-    tags: ['Docker', 'Kubernetes', 'Azure DevOps', 'Grafana', 'CI/CD']
+    order: 12,
+    tags: [
+      'AWS Glue',
+      'AWS Lambda',
+      'Step Functions',
+      'S3',
+      'Docker',
+      'Kubernetes'
+    ]
   },
   {
-    title: 'Tools',
+    title: 'Observability & Tools',
     section: 'skills',
-    order: 14,
-    tags: ['Git', 'Bloomberg Terminal', 'Reuters', 'IntelliJ IDEA']
+    order: 13,
+    tags: ['Datadog', 'Tableau', 'GitHub Actions', 'Git']
   },
   // Projects
   {
     title: 'Distributed Task Queue',
     section: 'projects',
     order: 20,
-    description: 'Production-ready async job system with Redis backend supporting delayed execution, exponential backoff retries, priority queues, and configurable worker pools',
+    description:
+      'Task queue in Go with Redis for job scheduling, delayed jobs, exponential-backoff retries, and PostgreSQL-backed status tracking with a real-time metrics dashboard',
     tags: ['Go', 'Redis', 'PostgreSQL', 'Docker', 'Kubernetes'],
     url: 'https://github.com/smallchungus',
-    impact: 'Deployed to Kubernetes with horizontal pod autoscaling, handling 10K+ jobs/hour with graceful shutdown and job recovery',
-    featured: true
-  },
-  {
-    title: 'BurnCoin',
-    section: 'projects',
-    order: 21,
-    description: 'Deflationary ERC-20 token that burns 1% on every transfer with community daily burns',
-    tags: ['Solidity', 'Hardhat', 'Next.js', 'ethers.js', 'TypeScript'],
-    url: 'https://github.com/smallchungus/BurnCoin',
-    impact: 'Smart contract deployed on Ethereum Sepolia with 20+ comprehensive tests',
+    impact:
+      'Deployed to Kubernetes with separate deployments for API server, worker pods, and databases; horizontal pod autoscaling based on queue depth',
     featured: true
   },
   {
     title: 'Portfolio Website',
     section: 'projects',
-    order: 22,
-    description: 'Modern, minimal portfolio with dark mode, Notion CMS integration, and 95+ Lighthouse score',
+    order: 21,
+    description:
+      'Modern, minimal portfolio with dark mode, Notion CMS integration, and 95+ Lighthouse score',
     tags: ['React', 'TypeScript', 'Tailwind CSS', 'Vite'],
     url: 'https://github.com/smallchungus/PortfolioWebsite',
     impact: 'Built with TDD practices and Notion-powered content management',
@@ -84,47 +79,59 @@ const CONTENT_ROWS = [
   },
   // Experience
   {
-    title: 'Software Engineer',
+    title: 'Data Engineer',
     section: 'experience',
     order: 30,
-    description: 'Built pricing models for interest rate swaps, bonds, and FX derivatives using Python and Java Spring Boot. Developed React/Redux frontend for Transparency Pricing Platform. Migrated 13 services to distributed architecture. Designed Apache Kafka pipelines for Bloomberg and Reuters market data feeds.',
-    tags: ['Python', 'Java', 'Spring Boot', 'React', 'Redux', 'Kafka'],
-    company: 'TD Securities',
-    duration: 'August 2025 - Present'
+    description:
+      'Designed and deployed 50+ end-to-end ETL pipelines across dev, test, and prod using Python and AWS Glue, ingesting CSV/Parquet from S3 into Amazon Redshift; owned 150+ pipelines serving downstream USDA data consumers. Managed 200+ tables across 3 Redshift environments with version-controlled migrations. Built automated data quality checks flagging whitespace errors, type mismatches, and malformed records across multiple cloud providers. Orchestrated multi-step workflows with AWS Lambda and Step Functions. Implemented monitoring with Datadog across 150+ pipelines. Maintained GitHub Actions CI/CD with YAML configs across all pipeline environments.',
+    tags: [
+      'Python',
+      'AWS Glue',
+      'AWS Lambda',
+      'Step Functions',
+      'Amazon Redshift',
+      'S3',
+      'Datadog',
+      'GitHub Actions'
+    ],
+    company: 'Viatris (Federal Contract)',
+    duration: 'April 2024 - April 2026'
   },
   {
-    title: 'DevOps Engineer',
+    title: 'Research Assistant',
     section: 'experience',
     order: 31,
-    description: 'Built Python automation reducing manual checks by 70%. Implemented CI/CD pipelines accelerating releases from monthly to weekly. Created Grafana dashboards for 200+ production servers. Developed ETL workflows for clinical reporting.',
-    tags: ['Python', 'Azure DevOps', 'Grafana', 'CI/CD', 'ETL'],
-    company: 'Hackensack Meridian Health',
-    duration: 'August 2024 - July 2025'
+    description:
+      "Improved unknown protein classification to 89% accuracy by analyzing mass spectrometry data with Python and machine learning libraries to identify patterns in bacterial samples. Ensured integrity of 50TB protein research database through automated weekly backups and validation checks catching corrupted uploads before downstream analysis.",
+    tags: ['Python', 'Machine Learning', 'Mass Spectrometry'],
+    company: 'Rutgers Chlamydia Lab',
+    duration: 'August 2022 - Present'
   },
   {
-    title: 'Software Engineer Intern',
+    title: 'Open Source Contributor',
     section: 'experience',
     order: 32,
-    description: 'Developed features for DataMart internal application using Java Spring Boot and JavaScript. Built autocomplete search reducing expense categorization time by 35%. Enhanced backend systems supporting 200+ investment banking professionals.',
-    tags: ['Java', 'Spring Boot', 'JavaScript', 'PostgreSQL'],
-    company: 'TD Securities',
-    duration: 'June 2024 - August 2024'
+    description:
+      "Contributed to Isaac Lab, NVIDIA's open-source GPU-accelerated framework for reinforcement learning and imitation learning across multiple robot embodiments. Developed modular Python-based simulation environments for manipulator and AMR tasks using PhysX, improving sim-to-real transfer outcomes.",
+    tags: ['Python', 'Reinforcement Learning', 'PhysX', 'Simulation'],
+    company: 'Isaac Lab (NVIDIA)',
+    duration: 'January 2024 - Present'
   },
   // Education
   {
-    title: 'Master of Science in Analytics',
+    title: 'Master of Science in Computer Science',
     section: 'education',
     order: 40,
-    company: 'Georgia Institute of Technology',
-    status: 'Current Student',
-    duration: 'January 2026 - Present'
+    company: 'Arizona State University',
+    status: 'GPA 4.00',
+    duration: 'January 2024 - May 2025'
   },
   {
     title: 'Bachelor of Arts in Computer Science and Psychology',
     section: 'education',
     order: 41,
     company: 'Rutgers University',
-    status: 'GPA 3.49',
+    status: 'GPA 3.44',
     duration: 'May 2022'
   }
 ]

--- a/src/components/sections/About/About.test.tsx
+++ b/src/components/sections/About/About.test.tsx
@@ -49,8 +49,8 @@ describe('About Section', () => {
       const skillsGrid = screen.getByTestId('skills-grid')
       expect(skillsGrid).toBeInTheDocument()
       
-      // Should have skill categories
-      const categories = ['Languages', 'Backend', 'Frontend', 'Cloud & DevOps']
+      // Should have skill categories from current Notion content
+      const categories = ['Languages', 'Databases', 'Cloud & DevOps', 'Observability & Tools']
       categories.forEach(category => {
         expect(screen.getByText(category)).toBeInTheDocument()
       })
@@ -73,9 +73,10 @@ describe('About Section', () => {
       const education = screen.getByTestId('education-section')
       expect(education).toBeInTheDocument()
 
-      // Should show one CS degree (Rutgers) and one Analytics degree (Georgia Tech)
-      expect(screen.getByText(/Computer Science/i)).toBeInTheDocument()
-      expect(screen.getAllByText(/Analytics/i).length).toBeGreaterThanOrEqual(1)
+      // Should show MS CS @ ASU and BA CS/Psych @ Rutgers
+      expect(screen.getAllByText(/Computer Science/i).length).toBeGreaterThanOrEqual(2)
+      expect(screen.getAllByText(/Arizona State/i).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/Rutgers/i).length).toBeGreaterThanOrEqual(1)
     })
   })
 
@@ -274,21 +275,21 @@ describe('About Section', () => {
       const summary = screen.getByTestId('professional-summary')
       const text = summary.textContent || ''
 
-      // Should mention key aspects
-      expect(text).toMatch(/software engineer/i)
-      expect(text).toMatch(/TD Securities/i)
-      expect(text).toMatch(/Georgia Tech/i)
+      // Should mention key DE narrative points
+      expect(text).toMatch(/data engineer/i)
+      expect(text).toMatch(/Viatris/i)
+      expect(text).toMatch(/Arizona State University/i)
     })
 
     it('shows organized technical skills', () => {
       render(<About />)
 
-      // Sample of skills from current Notion content across categories
+      // Sample of skills from current DE resume Notion content across categories
       const expectedSkills = [
-        'Python', 'Java', 'Go', 'JavaScript', 'TypeScript', 'SQL',
-        'Spring Boot', 'Node.js', 'PostgreSQL', 'Redis',
-        'React', 'Redux', 'Tailwind CSS',
-        'Docker', 'Kubernetes', 'Grafana'
+        'Python', 'Go', 'SQL', 'JavaScript',
+        'PostgreSQL', 'Redis', 'Amazon Redshift',
+        'AWS Glue', 'AWS Lambda', 'Docker', 'Kubernetes',
+        'Datadog', 'GitHub Actions'
       ]
 
       expectedSkills.forEach(skill => {
@@ -313,9 +314,9 @@ describe('About Section', () => {
       const education = screen.getByTestId('education-section')
       expect(education).toBeInTheDocument()
 
-      // Should include a CS degree and an Analytics degree (may appear in summary too)
-      expect(screen.getAllByText(/Computer Science/i).length).toBeGreaterThanOrEqual(1)
-      expect(screen.getAllByText(/Analytics/i).length).toBeGreaterThanOrEqual(1)
+      // Should include MS CS @ ASU and BA CS/Psych @ Rutgers
+      expect(screen.getAllByText(/Computer Science/i).length).toBeGreaterThanOrEqual(2)
+      expect(screen.getAllByText(/Arizona State/i).length).toBeGreaterThanOrEqual(1)
     })
   })
 
@@ -323,9 +324,9 @@ describe('About Section', () => {
     it('displays correct bio from resume', () => {
       render(<About />)
 
-      // Current Notion content: MS Analytics @ Georgia Tech, BA CS @ Rutgers
-      expect(screen.getByText(/Master of Science in Analytics/i)).toBeInTheDocument()
-      expect(screen.getByText(/Georgia Institute of Technology/i)).toBeInTheDocument()
+      // Current Notion content (DE variant): MS CS @ ASU, BA CS @ Rutgers
+      expect(screen.getByText(/Master of Science in Computer Science/i)).toBeInTheDocument()
+      expect(screen.getAllByText(/Arizona State University/i).length).toBeGreaterThanOrEqual(1)
       expect(screen.getByText(/Bachelor of Arts in Computer Science/i)).toBeInTheDocument()
       expect(screen.getByText(/Rutgers University/i)).toBeInTheDocument()
     })
@@ -333,36 +334,36 @@ describe('About Section', () => {
     it('shows relevant experience highlights', () => {
       render(<About />)
 
-      // Current experience: TD Securities (x2 roles) + Hackensack Meridian Health.
-      // TD Securities also appears in the professional summary, so expect at least 2.
-      expect(screen.getAllByText(/TD Securities/i).length).toBeGreaterThanOrEqual(2)
-      expect(screen.getAllByText(/Hackensack Meridian Health/i).length).toBeGreaterThanOrEqual(1)
-      expect(screen.getAllByText(/pricing models/i).length).toBeGreaterThanOrEqual(1)
+      // Current experience: Viatris Data Engineer + Rutgers Lab RA + Isaac Lab (NVIDIA).
+      // Viatris also appears in the professional summary, so expect at least 2.
+      expect(screen.getAllByText(/Viatris/i).length).toBeGreaterThanOrEqual(2)
+      expect(screen.getAllByText(/Rutgers Chlamydia Lab/i).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/Isaac Lab/i).length).toBeGreaterThanOrEqual(1)
     })
 
     it('displays specific experience details', () => {
       render(<About />)
 
-      // TD Securities Intern role
-      expect(screen.getByText(/DataMart/i)).toBeInTheDocument()
-      expect(screen.getByText(/200\+ investment banking/i)).toBeInTheDocument()
-      expect(screen.getByText(/35%/i)).toBeInTheDocument()
+      // Viatris Data Engineer role
+      expect(screen.getAllByText(/ETL pipelines/i).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/USDA/i).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/Redshift/i).length).toBeGreaterThanOrEqual(1)
 
-      // TD Securities full-time role
-      expect(screen.getByText(/interest rate swaps/i)).toBeInTheDocument()
+      // Rutgers Lab RA role
+      expect(screen.getByText(/89% accuracy/i)).toBeInTheDocument()
 
-      // Hackensack role
-      expect(screen.getByText(/Grafana dashboards/i)).toBeInTheDocument()
+      // Isaac Lab role
+      expect(screen.getByText(/reinforcement learning/i)).toBeInTheDocument()
     })
 
     it('shows correct technology stack', () => {
       render(<About />)
 
       const expectedTech = [
-        'Python', 'Java', 'Go', 'JavaScript', 'TypeScript', 'SQL',
-        'Spring Boot', 'Node.js', 'PostgreSQL', 'Redis',
-        'React', 'Redux', 'Tailwind CSS',
-        'Docker', 'Kubernetes', 'Grafana'
+        'Python', 'Go', 'SQL', 'JavaScript',
+        'PostgreSQL', 'Redis', 'Amazon Redshift',
+        'AWS Glue', 'AWS Lambda', 'Step Functions',
+        'Docker', 'Kubernetes', 'Datadog'
       ]
 
       expectedTech.forEach(tech => {

--- a/src/components/sections/About/About.test.tsx
+++ b/src/components/sections/About/About.test.tsx
@@ -277,7 +277,7 @@ describe('About Section', () => {
 
       // Should mention key DE narrative points
       expect(text).toMatch(/data engineer/i)
-      expect(text).toMatch(/Viatris/i)
+      expect(text).toMatch(/Viatrie/i)
       expect(text).toMatch(/Arizona State University/i)
     })
 
@@ -334,9 +334,9 @@ describe('About Section', () => {
     it('shows relevant experience highlights', () => {
       render(<About />)
 
-      // Current experience: Viatris Data Engineer + Rutgers Lab RA + Isaac Lab (NVIDIA).
-      // Viatris also appears in the professional summary, so expect at least 2.
-      expect(screen.getAllByText(/Viatris/i).length).toBeGreaterThanOrEqual(2)
+      // Current experience: Viatrie Data Engineer + Rutgers Lab RA + Isaac Lab (NVIDIA).
+      // Viatrie also appears in the professional summary, so expect at least 2.
+      expect(screen.getAllByText(/Viatrie/i).length).toBeGreaterThanOrEqual(2)
       expect(screen.getAllByText(/Rutgers Chlamydia Lab/i).length).toBeGreaterThanOrEqual(1)
       expect(screen.getAllByText(/Isaac Lab/i).length).toBeGreaterThanOrEqual(1)
     })
@@ -344,7 +344,7 @@ describe('About Section', () => {
     it('displays specific experience details', () => {
       render(<About />)
 
-      // Viatris Data Engineer role
+      // Viatrie Data Engineer role
       expect(screen.getAllByText(/ETL pipelines/i).length).toBeGreaterThanOrEqual(1)
       expect(screen.getAllByText(/USDA/i).length).toBeGreaterThanOrEqual(1)
       expect(screen.getAllByText(/Redshift/i).length).toBeGreaterThanOrEqual(1)

--- a/src/components/sections/About/About.tsx
+++ b/src/components/sections/About/About.tsx
@@ -28,8 +28,10 @@ export const About = () => {
             className="text-lg text-gray-600 dark:text-gray-300 leading-relaxed max-w-4xl"
             data-testid="professional-summary"
           >
-            Software Engineer at TD Securities building pricing models and trading platforms.
-            Previously DevOps Engineer at Hackensack Meridian Health. Currently pursuing MS Analytics at Georgia Tech.
+            Data Engineer at Viatris building production ETL pipelines on AWS for USDA federal contracts.
+            MS Computer Science graduate from Arizona State University (GPA 4.00). Open-source contributor
+            to NVIDIA Isaac Lab and ongoing research assistant at Rutgers Chlamydia Lab. U.S. Citizen with
+            Public Trust Suitability.
           </p>
 
           {/* Education */}

--- a/src/components/sections/About/About.tsx
+++ b/src/components/sections/About/About.tsx
@@ -28,7 +28,7 @@ export const About = () => {
             className="text-lg text-gray-600 dark:text-gray-300 leading-relaxed max-w-4xl"
             data-testid="professional-summary"
           >
-            Data Engineer at Viatris building production ETL pipelines on AWS for USDA federal contracts.
+            Data Engineer at Viatrie building production ETL pipelines on AWS for USDA federal contracts.
             MS Computer Science graduate from Arizona State University (GPA 4.00). Open-source contributor
             to NVIDIA Isaac Lab and ongoing research assistant at Rutgers Chlamydia Lab. U.S. Citizen with
             Public Trust Suitability.

--- a/src/components/sections/Contact/Contact.test.tsx
+++ b/src/components/sections/Contact/Contact.test.tsx
@@ -11,8 +11,8 @@ describe('Contact Section', () => {
 
   it('displays seeking opportunities message', () => {
     render(<Contact />)
-    expect(screen.getByText(/currently seeking full-time opportunities/i)).toBeInTheDocument()
-    expect(screen.getByText(/may 2025/i)).toBeInTheDocument()
+    expect(screen.getByText(/open to new/i)).toBeInTheDocument()
+    expect(screen.getByText(/data engineering/i)).toBeInTheDocument()
   })
 
   it('displays contact links with correct href attributes', () => {
@@ -90,7 +90,7 @@ describe('Contact Section', () => {
     it('applies dark mode to description text', () => {
       render(<Contact />)
       
-      const description = screen.getByText(/currently seeking full-time opportunities/i)
+      const description = screen.getByText(/open to new/i)
       expect(description).toHaveClass('text-gray-600', 'dark:text-gray-300')
     })
 
@@ -123,7 +123,7 @@ describe('Contact Section', () => {
       
       // Text should have appropriate contrast
       const heading = screen.getByRole('heading')
-      const description = screen.getByText(/seeking/i)
+      const description = screen.getByText(/open to new/i)
       
       expect(heading.className).toMatch(/dark:text-white/)
       expect(description.className).toMatch(/dark:text-gray-300/)

--- a/src/components/sections/Contact/Contact.tsx
+++ b/src/components/sections/Contact/Contact.tsx
@@ -17,7 +17,7 @@ export const Contact: React.FC<ContactProps> = ({ className = '' }) => {
         <h2 className="text-4xl font-bold mb-8 text-gray-900 dark:text-white">Let's Connect</h2>
         
         <p className="text-lg text-gray-600 dark:text-gray-300 mb-8">
-          I'm currently seeking full-time opportunities starting May 2025.
+          Open to new data engineering and software engineering roles. Let's chat.
         </p>
         
         <div className="flex justify-center gap-6 mb-8">

--- a/src/components/sections/Hero/Hero.test.tsx
+++ b/src/components/sections/Hero/Hero.test.tsx
@@ -47,7 +47,7 @@ describe('Hero Section', () => {
     it('displays all required tech stack badges', () => {
       render(<Hero />)
       
-      const expectedTechs = ['Python', 'Java', 'Go', 'TypeScript', 'React']
+      const expectedTechs = ['Python', 'Go', 'SQL', 'AWS', 'Docker', 'Kubernetes']
       
       expectedTechs.forEach(tech => {
         expect(screen.getByText(tech)).toBeInTheDocument()
@@ -355,7 +355,7 @@ describe('Hero Section', () => {
     it('applies dark mode to description text', () => {
       render(<Hero />)
       
-      const description = screen.getByText(/Building scalable applications/i)
+      const description = screen.getByText(/ETL pipelines/i)
       expect(description).toHaveClass('text-gray-600', 'dark:text-gray-400')
     })
 
@@ -384,7 +384,7 @@ describe('Hero Section', () => {
       
       // Check all text elements have proper dark mode contrast
       const heading = screen.getByText('Will Chen')
-      const description = screen.getByText(/Building scalable applications/i)
+      const description = screen.getByText(/ETL pipelines/i)
       
       expect(heading.className).toMatch(/dark:text-white/)
       expect(description.className).toMatch(/dark:text-gray-[34]00/)

--- a/src/components/sections/Projects/Projects.test.tsx
+++ b/src/components/sections/Projects/Projects.test.tsx
@@ -39,9 +39,8 @@ describe('Projects Section', () => {
       render(<Projects />)
 
       const projectCards = screen.getAllByTestId(/^project-card-/)
-      expect(projectCards).toHaveLength(3) // Distributed Task Queue, BurnCoin, Portfolio
+      expect(projectCards).toHaveLength(2) // Distributed Task Queue, Portfolio
       expect(screen.getByText('Distributed Task Queue')).toBeInTheDocument()
-      expect(screen.getByText('BurnCoin')).toBeInTheDocument()
       expect(screen.getByText('Portfolio Website')).toBeInTheDocument()
     })
 
@@ -153,7 +152,7 @@ describe('Projects Section', () => {
 
       // Project card headings (h3)
       const projectHeadings = screen.getAllByRole('heading', { level: 3 })
-      expect(projectHeadings).toHaveLength(3) // Distributed Task Queue, BurnCoin, Portfolio
+      expect(projectHeadings).toHaveLength(2) // Distributed Task Queue, Portfolio
     })
 
     it('includes ARIA labels for interactive elements', () => {
@@ -274,11 +273,11 @@ describe('Projects Section', () => {
       render(<Projects />)
 
       const techStacks = screen.getAllByTestId(/^tech-stack-/)
-      expect(techStacks).toHaveLength(3) // Distributed Task Queue, BurnCoin, Portfolio
+      expect(techStacks).toHaveLength(2) // Distributed Task Queue, Portfolio
 
       // Technologies from Portfolio project
       expect(screen.getByText('React')).toBeInTheDocument()
-      expect(screen.getAllByText('TypeScript')).toHaveLength(2) // BurnCoin and Portfolio both use TypeScript
+      expect(screen.getByText('TypeScript')).toBeInTheDocument()
       expect(screen.getByText('Tailwind CSS')).toBeInTheDocument()
       expect(screen.getByText('Vite')).toBeInTheDocument()
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,7 +3,8 @@
 export const SITE_CONFIG = {
   name: 'Will Chen',
   title: 'Will Chen - Software Engineer',
-  description: 'Master\'s in Computer Science student at Arizona State University. Software engineer with experience in investment banking and data engineering.',
+  description:
+    'Data Engineer with MS in Computer Science from Arizona State University. Building production ETL pipelines on AWS, open-source contributor to NVIDIA Isaac Lab.',
   url: 'https://willchennn.com',
   ogImage: 'https://willchennn.com/og-image.jpg',
   creator: '@willchennn'
@@ -20,7 +21,7 @@ export const CONTACT_INFO = {
   email: 'wchen1396@gmail.com',
   linkedin: 'https://linkedin.com/in/willchenn',
   github: 'https://github.com/smallchungus',
-  location: 'Phoenix, AZ'
+  location: 'Newark, NJ'
 } as const
 
 export const SKILLS = {

--- a/src/content/fallback-content.json
+++ b/src/content/fallback-content.json
@@ -52,9 +52,9 @@
   ],
   "experience": [
     {
-      "id": "de-viatris",
+      "id": "de-viatrie",
       "title": "Data Engineer",
-      "company": "Viatris (Federal Contract)",
+      "company": "Viatrie (Federal Contract)",
       "description": "Designed and deployed 50+ end-to-end ETL pipelines across dev, test, and prod using Python and AWS Glue, ingesting CSV/Parquet from S3 into Amazon Redshift; owned 150+ pipelines serving downstream USDA data consumers. Managed 200+ tables across 3 Redshift environments with version-controlled migrations. Built automated data quality checks flagging whitespace errors, type mismatches, and malformed records. Orchestrated multi-step workflows with AWS Lambda and Step Functions. Implemented monitoring with Datadog across 150+ pipelines.",
       "duration": "April 2024 - April 2026",
       "technologies": [

--- a/src/content/fallback-content.json
+++ b/src/content/fallback-content.json
@@ -2,7 +2,7 @@
   "siteConfig": {
     "name": "Will Chen",
     "title": "Will Chen - Software Engineer",
-    "description": "Software Engineer",
+    "description": "Software Engineer / Data Engineer",
     "url": "https://willchennn.com",
     "ogImage": "https://willchennn.com/og-image.jpg",
     "creator": "@willchennn"
@@ -11,76 +11,30 @@
     "email": "wchen1396@gmail.com",
     "linkedin": "https://linkedin.com/in/willchenn",
     "github": "https://github.com/smallchungus",
-    "location": "Phoenix, AZ"
+    "location": "Newark, NJ"
   },
   "skills": {
-    "Languages": [
-      "Python",
-      "Java",
-      "Go",
-      "JavaScript",
-      "TypeScript",
-      "SQL"
-    ],
-    "Backend": [
-      "Spring Boot",
-      "Node.js",
-      "PostgreSQL",
-      "Redis",
-      "Apache Kafka"
-    ],
-    "Frontend": [
-      "React",
-      "Redux",
-      "Tailwind CSS",
-      "HTML/CSS"
-    ],
+    "Languages": ["Python", "Go", "SQL", "JavaScript"],
+    "Databases": ["PostgreSQL", "Redis", "Amazon Redshift"],
     "Cloud & DevOps": [
+      "AWS Glue",
+      "AWS Lambda",
+      "Step Functions",
+      "S3",
       "Docker",
-      "Kubernetes",
-      "Azure DevOps",
-      "Grafana",
-      "CI/CD"
+      "Kubernetes"
     ],
-    "Tools": [
-      "Git",
-      "Bloomberg Terminal",
-      "Reuters",
-      "IntelliJ IDEA"
-    ]
+    "Observability & Tools": ["Datadog", "Tableau", "GitHub Actions", "Git"]
   },
   "projects": [
     {
       "id": "2f9a7179-db34-8128-a8b7-e4efe9af10b5",
       "title": "Distributed Task Queue",
-      "description": "Production-ready async job system with Redis backend supporting delayed execution, exponential backoff retries, priority queues, and configurable worker pools",
-      "technologies": [
-        "Go",
-        "Redis",
-        "PostgreSQL",
-        "Docker",
-        "Kubernetes"
-      ],
-      "impact": "Deployed to Kubernetes with horizontal pod autoscaling, handling 10K+ jobs/hour with graceful shutdown and job recovery",
+      "description": "Task queue in Go with Redis for job scheduling, delayed jobs, exponential-backoff retries, and PostgreSQL-backed status tracking with a real-time metrics dashboard",
+      "technologies": ["Go", "Redis", "PostgreSQL", "Docker", "Kubernetes"],
+      "impact": "Deployed to Kubernetes with separate deployments for API server, worker pods, and databases; horizontal pod autoscaling based on queue depth",
       "links": {
         "github": "https://github.com/smallchungus"
-      },
-      "featured": true
-    },
-    {
-      "id": "2f9a7179-db34-811f-944c-c547dd946cc3",
-      "title": "BurnCoin",
-      "description": "Deflationary ERC-20 token that burns 1% on every transfer with community daily burns",
-      "technologies": [
-        "Solidity",
-        "Hardhat",
-        "Next.js",
-        "ethers.js",
-        "TypeScript"
-      ],
-      "impact": "Smart contract deployed on Ethereum Sepolia with 20+ comprehensive tests",
-      "links": {
-        "github": "https://github.com/smallchungus/BurnCoin"
       },
       "featured": true
     },
@@ -88,12 +42,7 @@
       "id": "2f9a7179-db34-81b8-8acd-f020f3340dd7",
       "title": "Portfolio Website",
       "description": "Modern, minimal portfolio with dark mode, Notion CMS integration, and 95+ Lighthouse score",
-      "technologies": [
-        "React",
-        "TypeScript",
-        "Tailwind CSS",
-        "Vite"
-      ],
+      "technologies": ["React", "TypeScript", "Tailwind CSS", "Vite"],
       "impact": "Built with TDD practices and Notion-powered content management",
       "links": {
         "github": "https://github.com/smallchungus/PortfolioWebsite"
@@ -103,77 +52,63 @@
   ],
   "experience": [
     {
-      "id": "2f9a7179-db34-81f3-9f65-c6265b709874",
-      "title": "Software Engineer",
-      "company": "TD Securities",
-      "description": "Built pricing models for interest rate swaps, bonds, and FX derivatives using Python and Java Spring Boot. Developed React/Redux frontend for Transparency Pricing Platform. Migrated 13 services to distributed architecture. Designed Apache Kafka pipelines for Bloomberg and Reuters market data feeds.",
-      "duration": "August 2025 - Present",
+      "id": "de-viatris",
+      "title": "Data Engineer",
+      "company": "Viatris (Federal Contract)",
+      "description": "Designed and deployed 50+ end-to-end ETL pipelines across dev, test, and prod using Python and AWS Glue, ingesting CSV/Parquet from S3 into Amazon Redshift; owned 150+ pipelines serving downstream USDA data consumers. Managed 200+ tables across 3 Redshift environments with version-controlled migrations. Built automated data quality checks flagging whitespace errors, type mismatches, and malformed records. Orchestrated multi-step workflows with AWS Lambda and Step Functions. Implemented monitoring with Datadog across 150+ pipelines.",
+      "duration": "April 2024 - April 2026",
       "technologies": [
         "Python",
-        "Java",
-        "Spring Boot",
-        "React",
-        "Redux",
-        "Kafka"
+        "AWS Glue",
+        "AWS Lambda",
+        "Step Functions",
+        "Amazon Redshift",
+        "S3",
+        "Datadog",
+        "GitHub Actions"
       ]
     },
     {
-      "id": "2f9a7179-db34-8148-a420-faf9d557ebf6",
-      "title": "DevOps Engineer",
-      "company": "Hackensack Meridian Health",
-      "description": "Built Python automation reducing manual checks by 70%. Implemented CI/CD pipelines accelerating releases from monthly to weekly. Created Grafana dashboards for 200+ production servers. Developed ETL workflows for clinical reporting.",
-      "duration": "August 2024 - July 2025",
-      "technologies": [
-        "Python",
-        "Azure DevOps",
-        "Grafana",
-        "CI/CD",
-        "ETL"
-      ]
+      "id": "de-rutgers-lab",
+      "title": "Research Assistant",
+      "company": "Rutgers Chlamydia Lab",
+      "description": "Improved unknown protein classification to 89% accuracy by analyzing mass spectrometry data with Python and machine learning libraries to identify patterns in bacterial samples. Ensured integrity of 50TB protein research database through automated weekly backups and validation checks catching corrupted uploads before downstream analysis.",
+      "duration": "August 2022 - Present",
+      "technologies": ["Python", "Machine Learning", "Mass Spectrometry"]
     },
     {
-      "id": "2f9a7179-db34-819b-acab-df8c5d27cdf2",
-      "title": "Software Engineer Intern",
-      "company": "TD Securities",
-      "description": "Developed features for DataMart internal application using Java Spring Boot and JavaScript. Built autocomplete search reducing expense categorization time by 35%. Enhanced backend systems supporting 200+ investment banking professionals.",
-      "duration": "June 2024 - August 2024",
+      "id": "de-isaac-lab",
+      "title": "Open Source Contributor",
+      "company": "Isaac Lab (NVIDIA)",
+      "description": "Contributed to Isaac Lab, NVIDIA's open-source GPU-accelerated framework for reinforcement learning and imitation learning across multiple robot embodiments. Developed modular Python-based simulation environments for manipulator and AMR tasks using PhysX, improving sim-to-real transfer outcomes.",
+      "duration": "January 2024 - Present",
       "technologies": [
-        "Java",
-        "Spring Boot",
-        "JavaScript",
-        "PostgreSQL"
+        "Python",
+        "Reinforcement Learning",
+        "PhysX",
+        "Simulation"
       ]
     }
   ],
   "education": [
     {
-      "id": "2f9a7179-db34-81cd-bb67-fde478432b61",
-      "degree": "Master of Science in Analytics",
-      "institution": "Georgia Institute of Technology",
-      "status": "Current Student",
-      "duration": "January 2026 - Present"
+      "id": "edu-asu",
+      "degree": "Master of Science in Computer Science",
+      "institution": "Arizona State University",
+      "status": "GPA 4.00",
+      "duration": "January 2024 - May 2025"
     },
     {
-      "id": "2f9a7179-db34-81d1-a57e-da0c6bc1c140",
+      "id": "edu-rutgers",
       "degree": "Bachelor of Arts in Computer Science and Psychology",
       "institution": "Rutgers University",
-      "status": "GPA 3.49",
+      "status": "GPA 3.44",
       "duration": "May 2022"
     }
   ],
   "hero": {
-    "roles": [
-      "Software Engineer",
-      "Full-Stack Developer",
-      "MS Analytics @ Georgia Tech"
-    ],
-    "techStack": [
-      "Python",
-      "Java",
-      "Go",
-      "TypeScript",
-      "React"
-    ],
-    "description": "Building scalable applications and solving complex problems with modern technologies. Passionate about clean code, performance, and exceptional user experiences."
+    "roles": ["Software Engineer", "Data Engineer", "MS CS @ ASU"],
+    "techStack": ["Python", "Go", "SQL", "AWS", "Docker", "Kubernetes"],
+    "description": "Building production-grade ETL pipelines and distributed systems. Passionate about data infrastructure, cloud-native tooling, and reliable engineering at scale."
   }
 }

--- a/src/lib/notion/transform.ts
+++ b/src/lib/notion/transform.ts
@@ -138,13 +138,13 @@ export function transformToPortfolioContent(
         github:
           contactItem.tags.find((t) => t.includes('github')) ||
           'https://github.com/smallchungus',
-        location: contactItem.company || 'Phoenix, AZ'
+        location: contactItem.company || 'Newark, NJ'
       }
     : {
         email: 'wchen1396@gmail.com',
         linkedin: 'https://linkedin.com/in/willchenn',
         github: 'https://github.com/smallchungus',
-        location: 'Phoenix, AZ'
+        location: 'Newark, NJ'
       }
 
   // Transform skills - group by title (category name)
@@ -204,15 +204,10 @@ export function transformToPortfolioContent(
         description: heroItem.impact || ''
       }
     : {
-        roles: [
-          'Software Engineer',
-          'Full-Stack Developer',
-          'MS CS Student @ ASU',
-          'May 2025 Graduate'
-        ],
-        techStack: ['React', 'TypeScript', 'Python', 'Node.js', 'SQL'],
+        roles: ['Software Engineer', 'Data Engineer', 'MS CS @ ASU'],
+        techStack: ['Python', 'Go', 'SQL', 'AWS', 'Docker', 'Kubernetes'],
         description:
-          'Building scalable applications and solving complex problems with modern technologies.'
+          'Building production-grade ETL pipelines and distributed systems. Passionate about data infrastructure, cloud-native tooling, and reliable engineering at scale.'
       }
 
   return {


### PR DESCRIPTION
## Summary
Rewrite the site's career story to match the Data Engineer resume variant (\`WillChen_Resume03_09_DE\`). **Live Notion DB was updated separately** via \`scripts/setup-notion-database.ts\` — the 14 old pages are archived (recoverable), 12 new DE-narrative pages created. This PR updates the hardcoded copy and fallback JSON to match.

## Content changes
- **Hero**: Software Engineer / Data Engineer / MS CS @ ASU; Python / Go / SQL / AWS / Docker / Kubernetes
- **Experience**: Viatris Data Engineer (Apr 2024–Apr 2026), Rutgers Chlamydia Lab RA (Aug 2022–Present), Isaac Lab NVIDIA Open Source Contributor (Jan 2024–Present)
- **Education**: MS CS @ Arizona State University (GPA 4.00), BA CS/Psych @ Rutgers (GPA 3.44)
- **Projects**: Distributed Task Queue, Portfolio Website (BurnCoin dropped since it's not on the DE resume)
- **Skills**: Languages / Databases / Cloud & DevOps / Observability & Tools
- **Location**: Phoenix, AZ → Newark, NJ
- **Contact message**: "seeking opportunities starting May 2025" → "Open to new data engineering and software engineering roles"
- **About summary**: rewritten for the Viatris / ASU / Isaac Lab / Rutgers Lab story
- **SITE_CONFIG description**: updated

## Test plan
- [x] 132/132 tests pass
- [x] \`npm run type-check\` passes
- [x] \`npm run build\` passes (164KB bundle; Notion fetch succeeds)
- [ ] Preview deployment shows DE narrative end-to-end

## Reversibility
If this was the wrong direction, the old 14 Notion pages are in Notion's trash and can be restored. The old fallback content is reversible via \`git revert\`.