### PR TITLE
feat(analytics): add Vercel Speed Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@notionhq/client": "^2.2.15",
+        "@vercel/speed-insights": "^2.0.0",
         "dotenv": "^17.2.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2265,6 +2266,44 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@notionhq/client": "^2.2.15",
+    "@vercel/speed-insights": "^2.0.0",
     "dotenv": "^17.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import { SpeedInsights } from "@vercel/speed-insights/react";
 import { Navigation } from "./components/common/Navigation";
 import { Favicon } from "./components/common/Favicon";
 import { Hero } from "./components/sections/Hero";
@@ -18,6 +19,7 @@ const App = () => {
           <Contact />
         </main>
       </div>
+      <SpeedInsights />
     </>
   );
 };


### PR DESCRIPTION
Wires up Vercel Speed Insights for Core Web Vitals collection on willchennn.com.

Changes:
- npm install @vercel/speed-insights
- Import SpeedInsights from @vercel/speed-insights/react in App.jsx (not the /next variant — this is Vite + React, not Next.js)
- Render SpeedInsights at the app root

Result: Vercel dashboard will start showing FCP, LCP, INP, CLS, FID, TTFB from real traffic once users visit the site.

Bundle impact: +2KB gzipped.

Test plan:
- [x] 132/132 tests pass
- [x] type-check passes
- [x] build passes
- [ ] After merge, visit willchennn.com in a browser, then check Speed Insights dashboard for data points