### PR TITLE
feat(seo): add keywords, JSON-LD schema, robots.txt, sitemap

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,22 +4,107 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Will Chen - Software Engineer</title>
-    <meta name="description" content="Full-stack software engineer specializing in React, TypeScript, and scalable web applications. View my projects and experience.">
-    <meta name="author" content="Will Chen">
-    
+
+    <title>Will Chen | Data Engineer & Software Engineer | AWS, Python, Go</title>
+    <meta
+      name="description"
+      content="Will Chen — Data Engineer and Software Engineer in Newark, NJ. Builds production ETL pipelines on AWS (Glue, Lambda, Step Functions, Redshift). MS Computer Science, Arizona State University. Open-source contributor to NVIDIA Isaac Lab."
+    />
+    <meta name="author" content="Will Chen" />
+    <meta
+      name="keywords"
+      content="Will Chen, Data Engineer, Software Engineer, AWS Glue, ETL, Python, Go, React, TypeScript, Redshift, Kubernetes, Docker, Datadog, Newark NJ, Arizona State University, NVIDIA Isaac Lab, portfolio"
+    />
+    <link rel="canonical" href="https://willchennn.com" />
+
     <!-- Open Graph / Social Media -->
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Will Chen - Software Engineer">
-    <meta property="og:description" content="Full-stack software engineer specializing in React, TypeScript, and scalable web applications.">
-    <meta property="og:image" content="/favicon.svg">
-    <meta property="og:url" content="https://willchennn.com">
-    
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Will Chen | Data Engineer & Software Engineer" />
+    <meta
+      property="og:description"
+      content="Data Engineer building production ETL pipelines on AWS. MS Computer Science, Arizona State. Open-source contributor to NVIDIA Isaac Lab."
+    />
+    <meta property="og:image" content="https://willchennn.com/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:url" content="https://willchennn.com" />
+    <meta property="og:site_name" content="Will Chen" />
+    <meta property="og:locale" content="en_US" />
+
     <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="Will Chen - Software Engineer">
-    <meta name="twitter:description" content="Full-stack software engineer specializing in React, TypeScript, and scalable web applications.">
-    <meta name="twitter:image" content="/favicon.svg">
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Will Chen | Data Engineer & Software Engineer" />
+    <meta
+      name="twitter:description"
+      content="Data Engineer building production ETL pipelines on AWS. MS Computer Science, Arizona State. Open-source contributor to NVIDIA Isaac Lab."
+    />
+    <meta name="twitter:image" content="https://willchennn.com/og-image.png" />
+
+    <!-- JSON-LD Person schema for rich Google search results -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Will Chen",
+        "alternateName": "William Chen",
+        "url": "https://willchennn.com",
+        "image": "https://willchennn.com/og-image.png",
+        "jobTitle": "Data Engineer",
+        "description": "Data Engineer and Software Engineer building production ETL pipelines on AWS. MS Computer Science, Arizona State University.",
+        "email": "mailto:wchen1396@gmail.com",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Newark",
+          "addressRegion": "NJ",
+          "addressCountry": "US"
+        },
+        "alumniOf": [
+          {
+            "@type": "CollegeOrUniversity",
+            "name": "Arizona State University",
+            "sameAs": "https://www.asu.edu"
+          },
+          {
+            "@type": "CollegeOrUniversity",
+            "name": "Rutgers University",
+            "sameAs": "https://www.rutgers.edu"
+          }
+        ],
+        "knowsAbout": [
+          "Data Engineering",
+          "ETL Pipelines",
+          "AWS Glue",
+          "AWS Lambda",
+          "Step Functions",
+          "Amazon Redshift",
+          "Python",
+          "Go",
+          "SQL",
+          "Docker",
+          "Kubernetes",
+          "React",
+          "TypeScript"
+        ],
+        "sameAs": [
+          "https://github.com/smallchungus",
+          "https://linkedin.com/in/willchenn"
+        ]
+      }
+    </script>
+
+    <!-- JSON-LD WebSite schema -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Will Chen",
+        "url": "https://willchennn.com",
+        "author": {
+          "@type": "Person",
+          "name": "Will Chen"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://willchennn.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://willchennn.com/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Makes the site discoverable via Google / search engines.

What this adds:
- Rich meta description and keywords tuned to the DE narrative (AWS Glue, Python, Go, Redshift, ETL, Newark NJ, ASU, Isaac Lab)
- Canonical URL tag
- og:site_name, og:locale, og:image dimensions (1200x630)
- twitter:card upgraded from "summary" to "summary_large_image"
- JSON-LD Person schema (jobTitle, alumniOf, knowsAbout, sameAs) for rich Google results
- JSON-LD WebSite schema
- public/robots.txt (allow all, sitemap pointer)
- public/sitemap.xml

Known gap — user action needed: og-image.png referenced in meta tags does not exist at public/og-image.png. Without it, social previews (Twitter, LinkedIn, iMessage) will show broken or default images. Need a 1200x630 PNG dropped at that path in a follow-up commit.

After merge:
1. Submit sitemap at https://search.google.com/search-console for willchennn.com
2. Validate rich results at https://search.google.com/test/rich-results
3. Validate OG preview at https://www.opengraph.xyz/

Test plan:
- [x] 132/132 tests pass
- [x] type-check passes
- [x] build passes (dist/index.html: 1.30KB gzipped)