### PR TITLE
feat(ui): refined polish pass on Hero, About, Projects, Contact

### DIFF
--- a/src/components/sections/About/About.tsx
+++ b/src/components/sections/About/About.tsx
@@ -1,4 +1,5 @@
 import { Badge } from '../../ui/Badge'
+import { Reveal } from '../../ui/Reveal'
 import { skills, experience, education } from '@/content'
 
 export const About = () => {
@@ -16,9 +17,11 @@ export const About = () => {
       aria-label="About Will Chen - Professional background and skills"
     >
       {/* Section Heading */}
-      <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-16 text-center">
-        About Me
-      </h2>
+      <Reveal>
+        <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-16 text-center tracking-tight">
+          About Me
+        </h2>
+      </Reveal>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-16">
         {/* Professional Summary */}
@@ -39,7 +42,7 @@ export const About = () => {
             <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Education</h3>
             <div className="space-y-4">
               {education.map((edu) => (
-                <div key={edu.id} className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+                <div key={edu.id} className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 hover:-translate-y-0.5 hover:shadow-md dark:hover:shadow-2xl transition-all duration-300">
                   <h4 className="font-semibold text-gray-900 dark:text-white">{edu.degree}</h4>
                   <p className="text-gray-600 dark:text-gray-300 mt-1">{edu.institution}</p>
                   <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">{edu.status} {edu.duration && `• ${edu.duration}`}</p>
@@ -91,7 +94,7 @@ export const About = () => {
             {experience.map((exp) => (
               <div
                 key={exp.id}
-                className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6"
+                className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 hover:-translate-y-0.5 hover:shadow-md dark:hover:shadow-2xl transition-all duration-300"
               >
                 <div className="flex justify-between items-start mb-3">
                   <div>

--- a/src/components/sections/Contact/Contact.tsx
+++ b/src/components/sections/Contact/Contact.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Reveal } from '../../ui/Reveal'
 import { contactInfo, RESUME_PATH } from '@/content'
 
 interface ContactProps {
@@ -14,17 +15,21 @@ export const Contact: React.FC<ContactProps> = ({ className = '' }) => {
       aria-label="Contact information"
     >
       <div className="container mx-auto px-4 max-w-2xl text-center">
-        <h2 className="text-4xl font-bold mb-8 text-gray-900 dark:text-white">Let's Connect</h2>
-        
-        <p className="text-lg text-gray-600 dark:text-gray-300 mb-8">
-          Open to new data engineering and software engineering roles. Let's chat.
-        </p>
+        <Reveal>
+          <h2 className="text-4xl font-bold mb-8 text-gray-900 dark:text-white tracking-tight">Let's Connect</h2>
+        </Reveal>
+
+        <Reveal delay={100}>
+          <p className="text-lg text-gray-600 dark:text-gray-300 mb-8">
+            Open to new data engineering and software engineering roles. Let's chat.
+          </p>
+        </Reveal>
         
         <div className="flex justify-center gap-6 mb-8">
           <a 
             href={`mailto:${contactInfo.email}`} 
             aria-label="Email Will Chen" 
-            className="p-3 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors duration-200"
+            className="p-3 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 hover:-translate-y-0.5 transition-all duration-200"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -36,7 +41,7 @@ export const Contact: React.FC<ContactProps> = ({ className = '' }) => {
           <a 
             href={contactInfo.linkedin} 
             aria-label="LinkedIn Profile"
-            className="p-3 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors duration-200"
+            className="p-3 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 hover:-translate-y-0.5 transition-all duration-200"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -48,7 +53,7 @@ export const Contact: React.FC<ContactProps> = ({ className = '' }) => {
           <a 
             href={contactInfo.github} 
             aria-label="GitHub Profile"
-            className="p-3 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors duration-200"
+            className="p-3 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 hover:-translate-y-0.5 transition-all duration-200"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { useTypingAnimation } from '../../../hooks/useTypingAnimation'
 import { Badge } from '../../ui/Badge'
+import { Reveal } from '../../ui/Reveal'
 import { heroContent, RESUME_PATH } from '@/content'
 
 export const Hero = () => {
@@ -49,51 +50,61 @@ export const Hero = () => {
       >
         <div className="container mx-auto text-center max-w-4xl">
           {/* Main heading */}
-          <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-gray-900 dark:text-white mb-8 font-inter">
-            Will Chen
-          </h1>
+          <Reveal>
+            <h1 className="text-4xl md:text-6xl lg:text-7xl xl:text-8xl font-bold tracking-tight text-gray-900 dark:text-white mb-8 font-inter bg-gradient-to-br from-gray-900 via-gray-800 to-gray-500 dark:from-white dark:via-gray-100 dark:to-gray-400 bg-clip-text [-webkit-text-fill-color:transparent]">
+              Will Chen
+            </h1>
+          </Reveal>
 
           {/* Typing animation role */}
-          <h2 className="text-2xl md:text-3xl lg:text-4xl text-gray-600 dark:text-gray-300 mb-8 h-16 flex items-center justify-center">
-            <span
-              data-testid="typing-role"
-              className="font-light"
-            >
-              {displayedText}
-              {!prefersReducedMotion && <span className="animate-pulse ml-1">|</span>}
-            </span>
-          </h2>
+          <Reveal delay={120}>
+            <h2 className="text-2xl md:text-3xl lg:text-4xl text-gray-600 dark:text-gray-300 mb-8 h-16 flex items-center justify-center">
+              <span
+                data-testid="typing-role"
+                className="font-light tracking-tight"
+              >
+                {displayedText}
+                {!prefersReducedMotion && <span className="animate-pulse ml-1">|</span>}
+              </span>
+            </h2>
+          </Reveal>
 
           {/* Description */}
-          <p className="text-lg text-gray-600 dark:text-gray-400 mb-12 max-w-2xl mx-auto leading-relaxed">
-            {heroContent.description}
-          </p>
+          <Reveal delay={220}>
+            <p className="text-lg text-gray-600 dark:text-gray-400 mb-12 max-w-2xl mx-auto leading-relaxed">
+              {heroContent.description}
+            </p>
+          </Reveal>
 
           {/* Tech stack badges */}
-          <div className="flex flex-wrap justify-center gap-3 mb-12">
-            {techBadges}
-          </div>
+          <Reveal delay={320}>
+            <div className="flex flex-wrap justify-center gap-3 mb-12">
+              {techBadges}
+            </div>
+          </Reveal>
 
           {/* CTA buttons */}
-          <div
-            data-testid="cta-buttons"
-            className="flex flex-col sm:flex-row gap-4 justify-center"
-          >
-            <button
-              onClick={handleViewProjects}
-              className="px-8 py-3 bg-gray-900 dark:bg-blue-600 text-white rounded-lg hover:bg-gray-800 dark:hover:bg-blue-700 transition-colors font-medium focus:outline-none focus:ring-2 focus:ring-gray-500 dark:focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
-              aria-label="View projects section"
+          <Reveal delay={420}>
+            <div
+              data-testid="cta-buttons"
+              className="flex flex-col sm:flex-row gap-4 justify-center"
             >
-              View Projects
-            </button>
-            <button
-              onClick={handleViewResume}
-              className="px-8 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors font-medium focus:outline-none focus:ring-2 focus:ring-gray-500 dark:focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
-              aria-label="View resume PDF"
-            >
-              View Resume
-            </button>
-          </div>
+              <button
+                onClick={handleViewProjects}
+                className="px-8 py-3 bg-gray-900 dark:bg-blue-600 text-white rounded-lg hover:bg-gray-800 dark:hover:bg-blue-700 hover:-translate-y-0.5 hover:shadow-lg transition-all duration-200 font-medium focus:outline-none focus:ring-2 focus:ring-gray-500 dark:focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+                aria-label="View projects section"
+              >
+                View Projects
+              </button>
+              <button
+                onClick={handleViewResume}
+                className="px-8 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 hover:-translate-y-0.5 hover:shadow-md transition-all duration-200 font-medium focus:outline-none focus:ring-2 focus:ring-gray-500 dark:focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+                aria-label="View resume PDF"
+              >
+                View Resume
+              </button>
+            </div>
+          </Reveal>
         </div>
       </section>
     </section>

--- a/src/components/sections/Projects/Projects.tsx
+++ b/src/components/sections/Projects/Projects.tsx
@@ -1,4 +1,5 @@
 import { Badge } from '../../ui/Badge'
+import { Reveal } from '../../ui/Reveal'
 import { projects } from '@/content'
 
 export const Projects = () => {
@@ -10,19 +11,21 @@ export const Projects = () => {
       aria-label="Featured projects showcase"
     >
       {/* Section Heading */}
-      <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-16 text-center">
-        Featured Projects
-      </h2>
+      <Reveal>
+        <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-16 text-center tracking-tight">
+          Featured Projects
+        </h2>
+      </Reveal>
 
       {/* Projects Grid */}
       <div
         className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"
         data-testid="projects-grid"
       >
-        {projects.map((project) => (
+        {projects.map((project, i) => (
+          <Reveal key={project.id} delay={i * 100}>
           <article
-            key={project.id}
-            className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 hover:border-gray-300 dark:hover:border-gray-600 transition-colors duration-200"
+            className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 hover:border-gray-300 dark:hover:border-gray-600 hover:-translate-y-1 hover:shadow-lg dark:hover:shadow-2xl transition-all duration-300"
             data-testid={`project-card-${project.id}`}
             role="article"
           >
@@ -102,6 +105,7 @@ export const Projects = () => {
               </div>
             )}
           </article>
+          </Reveal>
         ))}
       </div>
     </section>

--- a/src/components/ui/Reveal.tsx
+++ b/src/components/ui/Reveal.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+import { useInView } from '../../hooks/useInView'
+
+interface RevealProps {
+  children: ReactNode
+  delay?: number
+  className?: string
+}
+
+export const Reveal = ({ children, delay = 0, className = '' }: RevealProps) => {
+  const { ref, inView } = useInView<HTMLDivElement>()
+
+  return (
+    <div
+      ref={ref}
+      className={`transition-all duration-700 ease-out ${
+        inView ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
+      } ${className}`}
+      style={{ transitionDelay: inView ? `${delay}ms` : '0ms' }}
+      data-testid="reveal"
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react'
+
+interface UseInViewOptions {
+  threshold?: number
+  rootMargin?: string
+  once?: boolean
+}
+
+export function useInView<T extends HTMLElement>({
+  threshold = 0.15,
+  rootMargin = '0px 0px -60px 0px',
+  once = true
+}: UseInViewOptions = {}) {
+  const ref = useRef<T | null>(null)
+  const [inView, setInView] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    // Fallback to "always visible" when IntersectionObserver is unavailable
+    // (old browsers, jsdom test environments) or reduced-motion is preferred.
+    if (typeof IntersectionObserver === 'undefined') {
+      setInView(true)
+      return
+    }
+
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    ).matches
+
+    if (prefersReducedMotion) {
+      setInView(true)
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setInView(true)
+          if (once) observer.disconnect()
+        } else if (!once) {
+          setInView(false)
+        }
+      },
+      { threshold, rootMargin }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold, rootMargin, once])
+
+  return { ref, inView }
+}


### PR DESCRIPTION
Option A from the frontend reevaluation. Minimal-foundation-kept, execution-upgraded.

What ships:
- src/hooks/useInView.ts — small IntersectionObserver hook with reduced-motion and jsdom fallbacks (falls back to "always visible" so tests and accessibility work)
- src/components/ui/Reveal.tsx — wrapper that fades+translates content in when scrolled into view, with optional stagger delay
- Hero: gradient heading via bg-clip-text (subtle, gray-to-gray in light, white-to-gray in dark — not a rainbow), text-8xl on xl screens, tracking-tight, staggered reveals on heading/role/description/badges/CTAs, CTA button lift on hover
- Projects: section-heading reveal, staggered reveal per card, hover lift + shadow on cards (2026-ish depth)
- About: section-heading reveal, hover lift on education and experience cards (skill cards left static since they're not interactive)
- Contact: reveal on heading + tagline, hover lift on social icons, tracking-tight

No new dependencies (Framer Motion considered and rejected for bundle size).

Bundle impact: +2KB JS, +3KB CSS.

Test plan:
- [x] 132/132 tests pass
- [x] type-check passes
- [x] build passes
- [x] useInView has reduced-motion fallback (users with prefers-reduced-motion see content statically)
- [ ] Preview deploy: scroll the page, verify reveals trigger; hover project cards, verify lift; toggle dark mode, verify gradient inverts