### PR TITLE
feat(ui): editorial polish v2 — numeric prefixes, mono dates, scroll progress

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { Navigation } from "./components/common/Navigation";
 import { Favicon } from "./components/common/Favicon";
+import { ScrollProgress } from "./components/common/ScrollProgress";
 import { Hero } from "./components/sections/Hero";
 import { About } from "./components/sections/About";
 import { Projects } from "./components/sections/Projects";
@@ -10,6 +11,7 @@ const App = () => {
   return (
     <>
       <Favicon />
+      <ScrollProgress />
       <div className="min-h-screen bg-white dark:bg-gray-900">
         <Navigation />
         <main className="bg-white dark:bg-gray-900 min-h-screen" role="main">

--- a/src/components/common/ScrollProgress/ScrollProgress.tsx
+++ b/src/components/common/ScrollProgress/ScrollProgress.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+
+export const ScrollProgress = () => {
+  const [progress, setProgress] = useState(0)
+
+  useEffect(() => {
+    const update = () => {
+      const scrollTop = window.scrollY
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight
+      const pct = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0
+      setProgress(Math.min(100, Math.max(0, pct)))
+    }
+
+    update()
+    window.addEventListener('scroll', update, { passive: true })
+    window.addEventListener('resize', update)
+    return () => {
+      window.removeEventListener('scroll', update)
+      window.removeEventListener('resize', update)
+    }
+  }, [])
+
+  return (
+    <div
+      aria-hidden="true"
+      className="fixed top-0 left-0 right-0 h-[2px] bg-transparent z-50 pointer-events-none"
+      data-testid="scroll-progress"
+    >
+      <div
+        className="h-full bg-gray-900 dark:bg-white transition-[width] duration-100 ease-out"
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  )
+}

--- a/src/components/common/ScrollProgress/index.ts
+++ b/src/components/common/ScrollProgress/index.ts
@@ -1,0 +1,1 @@
+export { ScrollProgress } from './ScrollProgress'

--- a/src/components/sections/About/About.tsx
+++ b/src/components/sections/About/About.tsx
@@ -19,6 +19,7 @@ export const About = () => {
       {/* Section Heading */}
       <Reveal>
         <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-16 text-center tracking-tight">
+          <span className="text-gray-400 dark:text-gray-600 font-mono font-normal text-xl md:text-2xl mr-3 align-middle">01 /</span>
           About Me
         </h2>
       </Reveal>
@@ -45,7 +46,7 @@ export const About = () => {
                 <div key={edu.id} className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 hover:-translate-y-0.5 hover:shadow-md dark:hover:shadow-2xl transition-all duration-300">
                   <h4 className="font-semibold text-gray-900 dark:text-white">{edu.degree}</h4>
                   <p className="text-gray-600 dark:text-gray-300 mt-1">{edu.institution}</p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">{edu.status} {edu.duration && `• ${edu.duration}`}</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 font-mono">{edu.status} {edu.duration && `• ${edu.duration}`}</p>
                 </div>
               ))}
             </div>
@@ -101,7 +102,7 @@ export const About = () => {
                     <h4 className="font-semibold text-gray-900 dark:text-white">{exp.title}</h4>
                     <p className="text-gray-700 dark:text-gray-300 font-medium">{exp.company}</p>
                   </div>
-                  <span className="text-sm text-gray-500 dark:text-gray-400">{exp.duration}</span>
+                  <span className="text-sm text-gray-500 dark:text-gray-400 font-mono">{exp.duration}</span>
                 </div>
                 <p className="text-gray-700 dark:text-gray-300 leading-relaxed">{exp.description}</p>
               </div>

--- a/src/components/sections/Contact/Contact.tsx
+++ b/src/components/sections/Contact/Contact.tsx
@@ -16,7 +16,10 @@ export const Contact: React.FC<ContactProps> = ({ className = '' }) => {
     >
       <div className="container mx-auto px-4 max-w-2xl text-center">
         <Reveal>
-          <h2 className="text-4xl font-bold mb-8 text-gray-900 dark:text-white tracking-tight">Let's Connect</h2>
+          <h2 className="text-4xl font-bold mb-8 text-gray-900 dark:text-white tracking-tight">
+            <span className="text-gray-400 dark:text-gray-600 font-mono font-normal text-xl md:text-2xl mr-3 align-middle">03 /</span>
+            Let's Connect
+          </h2>
         </Reveal>
 
         <Reveal delay={100}>

--- a/src/components/sections/Projects/Projects.tsx
+++ b/src/components/sections/Projects/Projects.tsx
@@ -13,6 +13,7 @@ export const Projects = () => {
       {/* Section Heading */}
       <Reveal>
         <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-16 text-center tracking-tight">
+          <span className="text-gray-400 dark:text-gray-600 font-mono font-normal text-xl md:text-2xl mr-3 align-middle">02 /</span>
           Featured Projects
         </h2>
       </Reveal>

--- a/src/index.css
+++ b/src/index.css
@@ -8,13 +8,26 @@
   html {
     @apply scroll-smooth;
   }
-  
+
   html.dark {
     @apply bg-gray-900;
   }
-  
+
   body {
     @apply bg-white dark:bg-gray-900;
+  }
+
+  /* Branded selection color. Subtle, matches engineer aesthetic. */
+  ::selection {
+    @apply bg-gray-900 text-white;
+  }
+  .dark ::selection {
+    @apply bg-white text-gray-900;
+  }
+
+  /* Hide default focus outlines only for mouse users; keep sharp rings for keyboard. */
+  :focus:not(:focus-visible) {
+    outline: none;
   }
 }
 


### PR DESCRIPTION
Option A-tighter. Keeps the minimal foundation, adds three small tasteful moves that signal "engineer who cares about execution" without shifting away from the DE positioning.

Changes:
- Numeric prefixes on section headings: About (01 /), Projects (02 /), Contact (03 /). Rendered in muted monospace at smaller size. Hero stays clean. Reads like editorial / code-comment numbering.
- Monospace font on experience + education dates. 'April 2024 - April 2026' now reads as tabular data, not body copy. Subtle DE signal.
- ScrollProgress component: 2px fixed bar at top of viewport showing scroll-through-page progress. Passive listener, pointer-events-none, aria-hidden, inverts in dark mode.
- index.css: branded ::selection color (gray-900 on white, white on gray-900). Focus ring kept only for keyboard navigation (:focus:not(:focus-visible)), removed from mouse clicks.

All DE-aligned: no cursor effects, no 3D, no gradients-as-decoration. Just more deliberate typography and unobtrusive utility.

Bundle: +1KB JS, +200B CSS.

Test plan:
- [x] 132/132 tests pass (toHaveTextContent substring matching preserves correctness across the numeric prefix change)
- [x] type-check passes
- [x] build passes
- [ ] Preview: check progress bar on scroll, mono rendering on dates, and focus behavior for keyboard tab navigation