### PR TITLE
feat(ui): analytics, nav indicator, PWA manifest, per-section titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#111827" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <title>Will Chen | Data Engineer & Software Engineer | AWS, Python, Go</title>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@notionhq/client": "^2.2.15",
+        "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "dotenv": "^17.2.3",
         "react": "^18.2.0",
@@ -2266,6 +2267,48 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vercel/speed-insights": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@notionhq/client": "^2.2.15",
+    "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "dotenv": "^17.2.3",
     "react": "^18.2.0",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "Will Chen — Data Engineer & Software Engineer",
+  "short_name": "Will Chen",
+  "description": "Portfolio of Will Chen, Data Engineer and Software Engineer building production ETL pipelines on AWS.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#111827",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { SpeedInsights } from "@vercel/speed-insights/react";
+import { Analytics } from "@vercel/analytics/react";
 import { Navigation } from "./components/common/Navigation";
 import { Favicon } from "./components/common/Favicon";
 import { ScrollProgress } from "./components/common/ScrollProgress";
@@ -6,8 +7,17 @@ import { Hero } from "./components/sections/Hero";
 import { About } from "./components/sections/About";
 import { Projects } from "./components/sections/Projects";
 import { Contact } from "./components/sections/Contact";
+import { useSectionTitle } from "./hooks/useSectionTitle";
+
+const SECTION_TITLES = [
+  { id: "about", title: "About" },
+  { id: "projects", title: "Featured Projects" },
+  { id: "contact", title: "Contact" },
+];
 
 const App = () => {
+  useSectionTitle(SECTION_TITLES);
+
   return (
     <>
       <Favicon />
@@ -22,6 +32,7 @@ const App = () => {
         </main>
       </div>
       <SpeedInsights />
+      <Analytics />
     </>
   );
 };

--- a/src/components/common/Navigation/Navigation.test.tsx
+++ b/src/components/common/Navigation/Navigation.test.tsx
@@ -67,7 +67,7 @@ describe('Navigation Component', () => {
     fireEvent.scroll(window);
     
     const aboutLink = screen.getByRole('link', { name: 'About' });
-    expect(aboutLink).toHaveClass('text-blue-600');
+    expect(aboutLink).toHaveClass('text-gray-900');
   });
 
   it('applies dark mode styles', () => {
@@ -133,7 +133,7 @@ describe('Navigation Component', () => {
     fireEvent.scroll(window);
     
     const projectsLink = screen.getByRole('link', { name: 'Projects' });
-    expect(projectsLink).toHaveClass('text-blue-600');
+    expect(projectsLink).toHaveClass('text-gray-900');
   });
 
   it('maintains accessibility with proper ARIA attributes', () => {

--- a/src/components/common/Navigation/Navigation.tsx
+++ b/src/components/common/Navigation/Navigation.tsx
@@ -49,19 +49,29 @@ export const Navigation = () => {
           <div className="flex items-center space-x-6">
             {/* Navigation Links */}
             <div className="hidden sm:flex space-x-8">
-              {NAV_ITEMS.map(item => (
-                <a
-                  key={item.href}
-                  href={item.href}
-                  className={`transition-colors font-medium ${
-                    activeSection === item.href.slice(1)
-                      ? 'text-blue-600 dark:text-blue-400'
-                      : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-                  }`}
-                >
-                  {item.label}
-                </a>
-              ))}
+              {NAV_ITEMS.map(item => {
+                const isActive = activeSection === item.href.slice(1)
+                return (
+                  <a
+                    key={item.href}
+                    href={item.href}
+                    aria-current={isActive ? 'page' : undefined}
+                    className={`relative transition-colors font-medium py-1 ${
+                      isActive
+                        ? 'text-gray-900 dark:text-white'
+                        : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+                    }`}
+                  >
+                    {item.label}
+                    <span
+                      aria-hidden="true"
+                      className={`absolute left-0 right-0 -bottom-0.5 h-[2px] bg-gray-900 dark:bg-white origin-left transition-transform duration-300 ease-out ${
+                        isActive ? 'scale-x-100' : 'scale-x-0'
+                      }`}
+                    />
+                  </a>
+                )
+              })}
             </div>
 
             {/* Theme Toggle */}

--- a/src/hooks/useSectionTitle.ts
+++ b/src/hooks/useSectionTitle.ts
@@ -1,0 +1,61 @@
+import { useEffect } from 'react'
+
+interface SectionTitleConfig {
+  id: string
+  title: string
+}
+
+const BASE_TITLE = 'Will Chen | Data Engineer & Software Engineer'
+
+/**
+ * Updates document.title based on which section is most visible in the viewport.
+ * Falls back to BASE_TITLE when no section dominates (e.g. page load at top).
+ */
+export function useSectionTitle(sections: SectionTitleConfig[]) {
+  useEffect(() => {
+    if (typeof IntersectionObserver === 'undefined') return
+
+    const originalTitle = document.title
+    let mostVisible: SectionTitleConfig | null = null
+    let maxRatio = 0
+
+    const updateTitle = () => {
+      document.title = mostVisible
+        ? `${mostVisible.title} — Will Chen`
+        : BASE_TITLE
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const config = sections.find((s) => s.id === entry.target.id)
+          if (!config) continue
+
+          if (entry.isIntersecting && entry.intersectionRatio > maxRatio) {
+            maxRatio = entry.intersectionRatio
+            mostVisible = config
+          } else if (!entry.isIntersecting && mostVisible?.id === config.id) {
+            mostVisible = null
+            maxRatio = 0
+          }
+        }
+        updateTitle()
+      },
+      { threshold: [0.25, 0.5, 0.75] }
+    )
+
+    const observed: Element[] = []
+    for (const section of sections) {
+      const el = document.getElementById(section.id)
+      if (el) {
+        observer.observe(el)
+        observed.push(el)
+      }
+    }
+
+    return () => {
+      observer.disconnect()
+      document.title = originalTitle
+    }
+  }, [sections])
+}


### PR DESCRIPTION
Four small features, bundled since none is large on its own. Independently useful; order-independent.

1. Vercel Analytics
- Adds @vercel/analytics and renders <Analytics /> at app root (sibling to the existing <SpeedInsights />). Starts collecting page views and referrers from real traffic. Visible in Vercel dashboard once deployed.

2. Navigation active-section indicator
- Animated underline that slides in under the active section link (scale-x-0 to scale-x-100, origin-left, 300ms ease-out). Replaces the previous blue-600 color swap with gray-900/white to match the site's grayscale palette. aria-current="page" on active. Tests updated to match.

3. PWA manifest
- public/manifest.webmanifest with name, short_name, description, theme_color (#111827), display: standalone. Linked from index.html along with <meta name="theme-color">. Enables Add-to-Home-Screen on mobile browsers and gives the site a proper PWA identity.

4. Per-section meta titles (useSectionTitle hook)
- IntersectionObserver watches About/Projects/Contact sections. document.title updates as user scrolls: "About — Will Chen", "Featured Projects — Will Chen", etc. Falls back to base title when no section dominates. Restores original title on unmount. SSR/jsdom-safe.

Out of scope (explicitly not in this PR):
- Multiple-URL sitemap: this is an SPA, all content lives at /, so adding fragment URLs (#about, #projects) to sitemap.xml doesn't provide real SEO benefit. Sitemap should get more URLs only when real routed pages are added (e.g. project case-study pages).

Bundle: +4KB gzipped (Vercel Analytics is the bulk).

Test plan:
- [x] 132/132 tests pass (including updated Navigation tests for new active-link color)
- [x] type-check passes
- [x] build passes
- [ ] Preview: scroll page, verify nav underline slides between sections; check tab title updates; check Vercel Analytics dashboard starts showing events