### PR TITLE
feat(content): resync site to latest main.tex resume

### DIFF
--- a/scripts/setup-notion-database.ts
+++ b/scripts/setup-notion-database.ts
@@ -9,7 +9,7 @@ const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID!
 
 const notion = new Client({ auth: NOTION_API_KEY })
 
-// Content to populate - Sourced from WillChen_Resume03_09_DE (Data Engineer variant)
+// Content to populate - Sourced from latest WillChen_Resume03_09_DE main.tex
 const CONTENT_ROWS = [
   // Hero
   {
@@ -17,41 +17,54 @@ const CONTENT_ROWS = [
     section: 'hero',
     order: 1,
     description: 'Python, Go, SQL, AWS, Docker, Kubernetes',
-    tags: ['Software Engineer', 'Data Engineer', 'MS CS @ ASU'],
+    tags: ['Software Engineer', 'Data Engineer', 'MS Analytics @ Georgia Tech'],
     impact:
       "Building production-grade ETL pipelines and distributed systems. Passionate about data infrastructure, cloud-native tooling, and reliable engineering at scale."
   },
-  // Skills (grouped from resume's "Languages & Databases" and "Cloud & Tools" sections)
+  // Skills — mirror the resume's three categories
   {
-    title: 'Languages',
+    title: 'Languages & Databases',
     section: 'skills',
     order: 10,
-    tags: ['Python', 'Go', 'SQL', 'JavaScript']
+    tags: [
+      'Python',
+      'Go',
+      'SQL',
+      'JavaScript',
+      'TypeScript',
+      'PostgreSQL',
+      'Redis',
+      'Amazon Redshift'
+    ]
   },
   {
-    title: 'Databases',
+    title: 'Cloud & Infrastructure',
     section: 'skills',
     order: 11,
-    tags: ['PostgreSQL', 'Redis', 'Amazon Redshift']
-  },
-  {
-    title: 'Cloud & DevOps',
-    section: 'skills',
-    order: 12,
     tags: [
       'AWS Glue',
       'AWS Lambda',
       'Step Functions',
       'S3',
       'Docker',
-      'Kubernetes'
+      'Kubernetes',
+      'GitHub Actions',
+      'Datadog',
+      'Bash'
     ]
   },
   {
-    title: 'Observability & Tools',
+    title: 'Tooling & Practices',
     section: 'skills',
-    order: 13,
-    tags: ['Datadog', 'Tableau', 'GitHub Actions', 'Git']
+    order: 12,
+    tags: [
+      'CI/CD',
+      'Distributed Systems',
+      'REST APIs',
+      'Observability',
+      'AI-assisted Development',
+      'Technical Documentation'
+    ]
   },
   // Projects
   {
@@ -59,11 +72,11 @@ const CONTENT_ROWS = [
     section: 'projects',
     order: 20,
     description:
-      'Task queue in Go with Redis for job scheduling, delayed jobs, exponential-backoff retries, and PostgreSQL-backed status tracking with a real-time metrics dashboard',
-    tags: ['Go', 'Redis', 'PostgreSQL', 'Docker', 'Kubernetes'],
+      'Distributed task queue in Go using Redis lists with BLPOP for blocking dequeue; processes 5K jobs across 4 workers in ~10 seconds. Worker and scheduler written from scratch instead of pulling in Celery to learn Go concurrency and Redis internals.',
+    tags: ['Go', 'Redis', 'PostgreSQL', 'Docker', 'Kubernetes', 'GitHub Actions'],
     url: 'https://github.com/smallchungus',
     impact:
-      'Deployed to Kubernetes with separate deployments for API server, worker pods, and databases; horizontal pod autoscaling based on queue depth',
+      'Worker crashes handled by 5-second Redis heartbeat; jobs from workers silent for 30+ seconds get requeued by a sweeper (at-least-once delivery without a separate broker). Containerized with Docker, deployed to Kubernetes with HPA on queue depth, CI/CD via GitHub Actions.',
     featured: true
   },
   {
@@ -79,11 +92,11 @@ const CONTENT_ROWS = [
   },
   // Experience
   {
-    title: 'Data Engineer',
+    title: 'Data Engineer (Federal Contract)',
     section: 'experience',
     order: 30,
     description:
-      'Designed and deployed 50+ end-to-end ETL pipelines across dev, test, and prod using Python and AWS Glue, ingesting CSV/Parquet from S3 into Amazon Redshift; owned 150+ pipelines serving downstream USDA data consumers. Managed 200+ tables across 3 Redshift environments with version-controlled migrations. Built automated data quality checks flagging whitespace errors, type mismatches, and malformed records across multiple cloud providers. Orchestrated multi-step workflows with AWS Lambda and Step Functions. Implemented monitoring with Datadog across 150+ pipelines. Maintained GitHub Actions CI/CD with YAML configs across all pipeline environments.',
+      'Shipped 50+ end-to-end ETL pipelines from S3 to Amazon Redshift in Python and AWS Glue; owned 150+ pipelines serving USDA data consumers. Reusable templates cut new-feed onboarding time by 50%. Re-architected multi-step workflows with AWS Lambda and Step Functions to kill recurring Glue timeouts, cutting end-to-end runtime by 60%. Rebuilt the deploy path with GitHub Actions CI/CD (tests, linting, multi-env promotion), taking deploys from ~1 hour to ~10 minutes and eliminating unplanned schema rollbacks across 200+ tables in 3 environments. Fail-fast data quality checks caught 3 upstream schema changes over 6 months before bad data reached USDA analyst dashboards. Instrumented 150+ pipelines in Datadog with SLA tracking and volume anomaly alerts. Shipped self-serve Tableau dashboards and runbooks serving 100+ USDA users, saving ~2 hours/week of ad-hoc report pulls.',
     tags: [
       'Python',
       'AWS Glue',
@@ -92,18 +105,19 @@ const CONTENT_ROWS = [
       'Amazon Redshift',
       'S3',
       'Datadog',
+      'Tableau',
       'GitHub Actions'
     ],
-    company: 'Viatrie (Federal Contract)',
-    duration: 'April 2024 - April 2026'
+    company: 'Viatrie',
+    duration: 'April 2024 - March 2026'
   },
   {
-    title: 'Research Assistant',
+    title: 'Research Software Engineer',
     section: 'experience',
     order: 31,
     description:
-      "Improved unknown protein classification to 89% accuracy by analyzing mass spectrometry data with Python and machine learning libraries to identify patterns in bacterial samples. Ensured integrity of 50TB protein research database through automated weekly backups and validation checks catching corrupted uploads before downstream analysis.",
-    tags: ['Python', 'Machine Learning', 'Mass Spectrometry'],
+      "Lifted unknown protein classification accuracy from ~70% to 89% by training scikit-learn ensemble models on mass-spectrometry data; serves 10-30 researchers, scientists, and doctors across 10+ collaborating labs in bacterial sample analysis. Cut 2+ hours of daily manual work by scripting instrument data processing in Python. Kept the 5TB research database intact with automated weekly backups and upload validation that catches corrupted writes before downstream analysis.",
+    tags: ['Python', 'scikit-learn', 'Machine Learning', 'Mass Spectrometry'],
     company: 'Rutgers Chlamydia Lab',
     duration: 'August 2022 - Present'
   },
@@ -112,19 +126,19 @@ const CONTENT_ROWS = [
     section: 'experience',
     order: 32,
     description:
-      "Contributed to Isaac Lab, NVIDIA's open-source GPU-accelerated framework for reinforcement learning and imitation learning across multiple robot embodiments. Developed modular Python-based simulation environments for manipulator and AMR tasks using PhysX, improving sim-to-real transfer outcomes.",
+      "Contribute to Isaac Lab, NVIDIA's open-source GPU-accelerated framework for reinforcement learning and imitation learning across multiple robot embodiments. Build modular Python simulation environments for manipulator and AMR tasks in PhysX.",
     tags: ['Python', 'Reinforcement Learning', 'PhysX', 'Simulation'],
     company: 'Isaac Lab (NVIDIA)',
     duration: 'January 2024 - Present'
   },
   // Education
   {
-    title: 'Master of Science in Computer Science',
+    title: 'Master of Science in Analytics',
     section: 'education',
     order: 40,
-    company: 'Arizona State University',
-    status: 'GPA 4.00',
-    duration: 'January 2024 - May 2025'
+    company: 'Georgia Institute of Technology',
+    status: 'Current Student',
+    duration: 'January 2026 - Present'
   },
   {
     title: 'Bachelor of Arts in Computer Science and Psychology',
@@ -132,7 +146,7 @@ const CONTENT_ROWS = [
     order: 41,
     company: 'Rutgers University',
     status: 'GPA 3.44',
-    duration: 'May 2022'
+    duration: 'Graduated May 2021'
   }
 ]
 

--- a/src/components/sections/About/About.test.tsx
+++ b/src/components/sections/About/About.test.tsx
@@ -50,7 +50,7 @@ describe('About Section', () => {
       expect(skillsGrid).toBeInTheDocument()
       
       // Should have skill categories from current Notion content
-      const categories = ['Languages', 'Databases', 'Cloud & DevOps', 'Observability & Tools']
+      const categories = ['Languages & Databases', 'Cloud & Infrastructure', 'Tooling & Practices']
       categories.forEach(category => {
         expect(screen.getByText(category)).toBeInTheDocument()
       })
@@ -73,9 +73,10 @@ describe('About Section', () => {
       const education = screen.getByTestId('education-section')
       expect(education).toBeInTheDocument()
 
-      // Should show MS CS @ ASU and BA CS/Psych @ Rutgers
-      expect(screen.getAllByText(/Computer Science/i).length).toBeGreaterThanOrEqual(2)
-      expect(screen.getAllByText(/Arizona State/i).length).toBeGreaterThanOrEqual(1)
+      // Should show MS Analytics @ Georgia Tech and BA CS/Psych @ Rutgers
+      expect(screen.getAllByText(/Analytics/i).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/Computer Science/i).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/Georgia/i).length).toBeGreaterThanOrEqual(1)
       expect(screen.getAllByText(/Rutgers/i).length).toBeGreaterThanOrEqual(1)
     })
   })
@@ -278,7 +279,7 @@ describe('About Section', () => {
       // Should mention key DE narrative points
       expect(text).toMatch(/data engineer/i)
       expect(text).toMatch(/Viatrie/i)
-      expect(text).toMatch(/Arizona State University/i)
+      expect(text).toMatch(/Georgia Tech/i)
     })
 
     it('shows organized technical skills', () => {
@@ -314,9 +315,9 @@ describe('About Section', () => {
       const education = screen.getByTestId('education-section')
       expect(education).toBeInTheDocument()
 
-      // Should include MS CS @ ASU and BA CS/Psych @ Rutgers
-      expect(screen.getAllByText(/Computer Science/i).length).toBeGreaterThanOrEqual(2)
-      expect(screen.getAllByText(/Arizona State/i).length).toBeGreaterThanOrEqual(1)
+      // Should include MS Analytics @ Georgia Tech and BA CS/Psych @ Rutgers
+      expect(screen.getAllByText(/Analytics/i).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/Rutgers/i).length).toBeGreaterThanOrEqual(1)
     })
   })
 
@@ -324,9 +325,9 @@ describe('About Section', () => {
     it('displays correct bio from resume', () => {
       render(<About />)
 
-      // Current Notion content (DE variant): MS CS @ ASU, BA CS @ Rutgers
-      expect(screen.getByText(/Master of Science in Computer Science/i)).toBeInTheDocument()
-      expect(screen.getAllByText(/Arizona State University/i).length).toBeGreaterThanOrEqual(1)
+      // Current Notion content: MS Analytics @ Georgia Tech, BA CS @ Rutgers
+      expect(screen.getByText(/Master of Science in Analytics/i)).toBeInTheDocument()
+      expect(screen.getByText(/Georgia Institute of Technology/i)).toBeInTheDocument()
       expect(screen.getByText(/Bachelor of Arts in Computer Science/i)).toBeInTheDocument()
       expect(screen.getByText(/Rutgers University/i)).toBeInTheDocument()
     })
@@ -349,8 +350,8 @@ describe('About Section', () => {
       expect(screen.getAllByText(/USDA/i).length).toBeGreaterThanOrEqual(1)
       expect(screen.getAllByText(/Redshift/i).length).toBeGreaterThanOrEqual(1)
 
-      // Rutgers Lab RA role
-      expect(screen.getByText(/89% accuracy/i)).toBeInTheDocument()
+      // Rutgers Lab role — resume says "from ~70% to 89%"
+      expect(screen.getByText(/89%/)).toBeInTheDocument()
 
       // Isaac Lab role
       expect(screen.getByText(/reinforcement learning/i)).toBeInTheDocument()

--- a/src/components/sections/About/About.tsx
+++ b/src/components/sections/About/About.tsx
@@ -32,10 +32,10 @@ export const About = () => {
             className="text-lg text-gray-600 dark:text-gray-300 leading-relaxed max-w-4xl"
             data-testid="professional-summary"
           >
-            Data Engineer at Viatrie building production ETL pipelines on AWS for USDA federal contracts.
-            MS Computer Science graduate from Arizona State University (GPA 4.00). Open-source contributor
-            to NVIDIA Isaac Lab and ongoing research assistant at Rutgers Chlamydia Lab. U.S. Citizen with
-            Public Trust Suitability.
+            Data Engineer at Viatrie building production ETL pipelines on AWS for USDA federal contracts —
+            150+ pipelines, 200+ tables across 3 environments. Currently pursuing MS Analytics at Georgia
+            Tech. Open-source contributor to NVIDIA Isaac Lab and research software engineer at Rutgers
+            Chlamydia Lab. U.S. Citizen with Public Trust Suitability.
           </p>
 
           {/* Education */}

--- a/src/content/fallback-content.json
+++ b/src/content/fallback-content.json
@@ -14,32 +14,50 @@
     "location": "Newark, NJ"
   },
   "skills": {
-    "Languages": ["Python", "Go", "SQL", "JavaScript"],
-    "Databases": ["PostgreSQL", "Redis", "Amazon Redshift"],
-    "Cloud & DevOps": [
+    "Languages & Databases": [
+      "Python",
+      "Go",
+      "SQL",
+      "JavaScript",
+      "TypeScript",
+      "PostgreSQL",
+      "Redis",
+      "Amazon Redshift"
+    ],
+    "Cloud & Infrastructure": [
       "AWS Glue",
       "AWS Lambda",
       "Step Functions",
       "S3",
       "Docker",
-      "Kubernetes"
+      "Kubernetes",
+      "GitHub Actions",
+      "Datadog",
+      "Bash"
     ],
-    "Observability & Tools": ["Datadog", "Tableau", "GitHub Actions", "Git"]
+    "Tooling & Practices": [
+      "CI/CD",
+      "Distributed Systems",
+      "REST APIs",
+      "Observability",
+      "AI-assisted Development",
+      "Technical Documentation"
+    ]
   },
   "projects": [
     {
-      "id": "2f9a7179-db34-8128-a8b7-e4efe9af10b5",
+      "id": "de-distributed-task-queue",
       "title": "Distributed Task Queue",
-      "description": "Task queue in Go with Redis for job scheduling, delayed jobs, exponential-backoff retries, and PostgreSQL-backed status tracking with a real-time metrics dashboard",
-      "technologies": ["Go", "Redis", "PostgreSQL", "Docker", "Kubernetes"],
-      "impact": "Deployed to Kubernetes with separate deployments for API server, worker pods, and databases; horizontal pod autoscaling based on queue depth",
+      "description": "Distributed task queue in Go using Redis lists with BLPOP for blocking dequeue; processes 5K jobs across 4 workers in ~10 seconds. Worker and scheduler written from scratch instead of pulling in Celery to learn Go concurrency and Redis internals.",
+      "technologies": ["Go", "Redis", "PostgreSQL", "Docker", "Kubernetes", "GitHub Actions"],
+      "impact": "Worker crashes handled by 5-second Redis heartbeat; jobs from workers silent for 30+ seconds get requeued by a sweeper (at-least-once delivery without a separate broker). Containerized with Docker, deployed to Kubernetes with HPA on queue depth, CI/CD via GitHub Actions.",
       "links": {
         "github": "https://github.com/smallchungus"
       },
       "featured": true
     },
     {
-      "id": "2f9a7179-db34-81b8-8acd-f020f3340dd7",
+      "id": "de-portfolio-website",
       "title": "Portfolio Website",
       "description": "Modern, minimal portfolio with dark mode, Notion CMS integration, and 95+ Lighthouse score",
       "technologies": ["React", "TypeScript", "Tailwind CSS", "Vite"],
@@ -53,10 +71,10 @@
   "experience": [
     {
       "id": "de-viatrie",
-      "title": "Data Engineer",
-      "company": "Viatrie (Federal Contract)",
-      "description": "Designed and deployed 50+ end-to-end ETL pipelines across dev, test, and prod using Python and AWS Glue, ingesting CSV/Parquet from S3 into Amazon Redshift; owned 150+ pipelines serving downstream USDA data consumers. Managed 200+ tables across 3 Redshift environments with version-controlled migrations. Built automated data quality checks flagging whitespace errors, type mismatches, and malformed records. Orchestrated multi-step workflows with AWS Lambda and Step Functions. Implemented monitoring with Datadog across 150+ pipelines.",
-      "duration": "April 2024 - April 2026",
+      "title": "Data Engineer (Federal Contract)",
+      "company": "Viatrie",
+      "description": "Shipped 50+ end-to-end ETL pipelines from S3 to Amazon Redshift in Python and AWS Glue; owned 150+ pipelines serving USDA data consumers. Reusable templates cut new-feed onboarding time by 50%. Re-architected multi-step workflows with AWS Lambda and Step Functions to kill recurring Glue timeouts, cutting end-to-end runtime by 60%. Rebuilt the deploy path with GitHub Actions CI/CD, taking deploys from ~1 hour to ~10 minutes and eliminating unplanned schema rollbacks across 200+ tables in 3 environments. Fail-fast data quality checks caught 3 upstream schema changes over 6 months before bad data reached USDA analyst dashboards. Instrumented 150+ pipelines in Datadog with SLA tracking and volume anomaly alerts. Shipped self-serve Tableau dashboards and runbooks serving 100+ USDA users.",
+      "duration": "April 2024 - March 2026",
       "technologies": [
         "Python",
         "AWS Glue",
@@ -65,49 +83,45 @@
         "Amazon Redshift",
         "S3",
         "Datadog",
+        "Tableau",
         "GitHub Actions"
       ]
     },
     {
       "id": "de-rutgers-lab",
-      "title": "Research Assistant",
+      "title": "Research Software Engineer",
       "company": "Rutgers Chlamydia Lab",
-      "description": "Improved unknown protein classification to 89% accuracy by analyzing mass spectrometry data with Python and machine learning libraries to identify patterns in bacterial samples. Ensured integrity of 50TB protein research database through automated weekly backups and validation checks catching corrupted uploads before downstream analysis.",
+      "description": "Lifted unknown protein classification accuracy from ~70% to 89% by training scikit-learn ensemble models on mass-spectrometry data; serves 10-30 researchers, scientists, and doctors across 10+ collaborating labs in bacterial sample analysis. Cut 2+ hours of daily manual work by scripting instrument data processing in Python. Kept the 5TB research database intact with automated weekly backups and upload validation that catches corrupted writes before downstream analysis.",
       "duration": "August 2022 - Present",
-      "technologies": ["Python", "Machine Learning", "Mass Spectrometry"]
+      "technologies": ["Python", "scikit-learn", "Machine Learning", "Mass Spectrometry"]
     },
     {
       "id": "de-isaac-lab",
       "title": "Open Source Contributor",
       "company": "Isaac Lab (NVIDIA)",
-      "description": "Contributed to Isaac Lab, NVIDIA's open-source GPU-accelerated framework for reinforcement learning and imitation learning across multiple robot embodiments. Developed modular Python-based simulation environments for manipulator and AMR tasks using PhysX, improving sim-to-real transfer outcomes.",
+      "description": "Contribute to Isaac Lab, NVIDIA's open-source GPU-accelerated framework for reinforcement learning and imitation learning across multiple robot embodiments. Build modular Python simulation environments for manipulator and AMR tasks in PhysX.",
       "duration": "January 2024 - Present",
-      "technologies": [
-        "Python",
-        "Reinforcement Learning",
-        "PhysX",
-        "Simulation"
-      ]
+      "technologies": ["Python", "Reinforcement Learning", "PhysX", "Simulation"]
     }
   ],
   "education": [
     {
-      "id": "edu-asu",
-      "degree": "Master of Science in Computer Science",
-      "institution": "Arizona State University",
-      "status": "GPA 4.00",
-      "duration": "January 2024 - May 2025"
+      "id": "edu-gatech",
+      "degree": "Master of Science in Analytics",
+      "institution": "Georgia Institute of Technology",
+      "status": "Current Student",
+      "duration": "January 2026 - Present"
     },
     {
       "id": "edu-rutgers",
       "degree": "Bachelor of Arts in Computer Science and Psychology",
       "institution": "Rutgers University",
       "status": "GPA 3.44",
-      "duration": "May 2022"
+      "duration": "Graduated May 2021"
     }
   ],
   "hero": {
-    "roles": ["Software Engineer", "Data Engineer", "MS CS @ ASU"],
+    "roles": ["Software Engineer", "Data Engineer", "MS Analytics @ Georgia Tech"],
     "techStack": ["Python", "Go", "SQL", "AWS", "Docker", "Kubernetes"],
     "description": "Building production-grade ETL pipelines and distributed systems. Passionate about data infrastructure, cloud-native tooling, and reliable engineering at scale."
   }


### PR DESCRIPTION
Pulls the latest copy from [WillChen_Resume03_09_DE/main.tex](https://github.com/smallchungus/WillChen_Resume03_09_DE/blob/main/main.tex) and syncs the site to match.

## What changed

**Education**
- Previous: MS Computer Science @ Arizona State (GPA 4.00, Jan 2024 - May 2025)
- New: **MS Analytics @ Georgia Institute of Technology** (Current Student, Jan 2026 - Present)
- Rutgers BA graduation year corrected from May 2022 → **May 2021**

**Viatrie (Data Engineer, Federal Contract)**
- End date Apr 2026 → Mar 2026
- Bullets rewritten with richer metrics: 50% onboarding time cut, 60% end-to-end runtime reduction, ~1h → ~10min deploy time, 3 upstream schema changes caught over 6 months, 100+ USDA users served via Tableau

**Rutgers Chlamydia Lab**
- Title: Research Assistant → **Research Software Engineer**
- DB size 50TB → 5TB (matches resume's actual figure, was a transcription error before)
- Accuracy framed as ~70% → 89% (shows the lift, not just the final number)
- Reach: 10-30 researchers across 10+ collaborating labs

**Distributed Task Queue**
- Description upgraded with specifics: 5K jobs / 4 workers / ~10s throughput, 5s heartbeat + 30s sweeper for at-least-once delivery, written from scratch vs Celery to learn Go concurrency and Redis internals

**Skills**
- Restructured into the resume's three groups: *Languages & Databases*, *Cloud & Infrastructure*, *Tooling & Practices*

**Hero + About**
- Hero roles: 'MS CS @ ASU' → 'MS Analytics @ Georgia Tech'
- About summary rewritten to match new narrative

## Execution

- Live Notion DB re-populated via \`npx tsx scripts/setup-notion-database.ts\` (14 old pages archived, 11 new created)
- Hardcoded fallback JSON + About summary updated to match
- Test assertions updated — 132/132 pass

## Test plan
- [x] 132/132 tests pass
- [x] type-check passes
- [x] build passes (prebuild regenerates notion-content.json from updated Notion)
- [ ] Preview deploy: verify Georgia Tech shows in Education, Viatrie bullets reflect new metrics, Distributed Task Queue description reads correctly