### PR TITLE
feat(sync): auto-sync site content from resume .tex

### DIFF
--- a/.github/workflows/sync-resume.yml
+++ b/.github/workflows/sync-resume.yml
@@ -1,0 +1,65 @@
+name: Sync from Resume
+
+# Auto-sync Notion content from the latest main.tex in the resume repo.
+# Triggered by:
+#   - Manual dispatch (workflow_dispatch)
+#   - Repository dispatch (repository_dispatch type=resume-updated) —
+#     fired by a one-line workflow in the resume repo if you want push-time sync
+#   - Every 30 minutes (schedule) as a safety net
+#
+# Requires these secrets in repo Settings → Secrets and variables → Actions:
+#   NOTION_API_KEY           internal integration token from notion.so/my-integrations
+#   NOTION_DATABASE_ID       the database ID the integration is shared with
+#
+# Optional:
+#   VERCEL_DEPLOY_HOOK_URL   Vercel deploy hook URL. If set, the job triggers
+#                            a redeploy after a successful Notion update so the
+#                            live site picks up the changes immediately rather
+#                            than waiting for the next code push. Create one at
+#                            Vercel → Project Settings → Git → Deploy Hooks.
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [resume-updated]
+  schedule:
+    # Every 30 minutes. GitHub may delay scheduled runs under load; that's OK
+    # because this is non-blocking — the site still builds fine from existing
+    # Notion content while the sync catches up.
+    - cron: '*/30 * * * *'
+
+jobs:
+  sync:
+    name: Parse resume and update Notion
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run sync
+        env:
+          NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
+        run: npx tsx scripts/sync-from-resume.ts
+
+      - name: Trigger Vercel redeploy (if hook configured)
+        env:
+          VERCEL_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -n "$VERCEL_DEPLOY_HOOK_URL" ]; then
+            echo "Triggering Vercel redeploy..."
+            curl -sS -X POST "$VERCEL_DEPLOY_HOOK_URL"
+          else
+            echo "VERCEL_DEPLOY_HOOK_URL secret not set; skipping redeploy. Next git push will pick up Notion changes."
+          fi

--- a/scripts/lib/notion-sync.ts
+++ b/scripts/lib/notion-sync.ts
@@ -1,0 +1,133 @@
+/* eslint-disable no-console */
+import { Client } from '@notionhq/client'
+import type { ContentRow } from './parse-resume-tex.js'
+
+/**
+ * Shared Notion client helpers used by both the hardcoded seed script
+ * (setup-notion-database.ts) and the auto-sync script (sync-from-resume.ts).
+ */
+
+export function getNotionClient() {
+  const apiKey = process.env.NOTION_API_KEY
+  const databaseId = process.env.NOTION_DATABASE_ID
+  if (!apiKey || !databaseId) {
+    throw new Error(
+      'NOTION_API_KEY and NOTION_DATABASE_ID must be set in the environment.'
+    )
+  }
+  return { notion: new Client({ auth: apiKey }), databaseId }
+}
+
+export async function updateDatabaseSchema(
+  notion: Client,
+  databaseId: string
+): Promise<void> {
+  await notion.databases.update({
+    database_id: databaseId,
+    properties: {
+      Section: {
+        select: {
+          options: [
+            { name: 'siteConfig', color: 'gray' },
+            { name: 'contact', color: 'blue' },
+            { name: 'skills', color: 'green' },
+            { name: 'projects', color: 'purple' },
+            { name: 'experience', color: 'orange' },
+            { name: 'education', color: 'yellow' },
+            { name: 'hero', color: 'red' }
+          ]
+        }
+      },
+      Order: { number: {} },
+      Description: { rich_text: {} },
+      Tags: { multi_select: { options: [] } },
+      URL: { url: {} },
+      Duration: { rich_text: {} },
+      Impact: { rich_text: {} },
+      Company: { rich_text: {} },
+      Status: { rich_text: {} },
+      Featured: { checkbox: {} }
+    }
+  })
+}
+
+export async function clearExistingPages(
+  notion: Client,
+  databaseId: string
+): Promise<number> {
+  const response = await notion.databases.query({ database_id: databaseId })
+  for (const page of response.results) {
+    await notion.pages.update({ page_id: page.id, archived: true })
+  }
+  return response.results.length
+}
+
+export async function createPage(
+  notion: Client,
+  databaseId: string,
+  row: ContentRow
+): Promise<void> {
+  const properties: Record<string, unknown> = {
+    Name: { title: [{ text: { content: row.title } }] },
+    Section: { select: { name: row.section } },
+    Order: { number: row.order }
+  }
+
+  if (row.description) {
+    properties.Description = {
+      rich_text: [{ text: { content: row.description } }]
+    }
+  }
+  if (row.tags && row.tags.length > 0) {
+    properties.Tags = {
+      multi_select: row.tags.map((tag) => ({ name: tag }))
+    }
+  }
+  if (row.url) properties.URL = { url: row.url }
+  if (row.duration) {
+    properties.Duration = {
+      rich_text: [{ text: { content: row.duration } }]
+    }
+  }
+  if (row.impact) {
+    properties.Impact = { rich_text: [{ text: { content: row.impact } }] }
+  }
+  if (row.company) {
+    properties.Company = { rich_text: [{ text: { content: row.company } }] }
+  }
+  if (row.status) {
+    properties.Status = { rich_text: [{ text: { content: row.status } }] }
+  }
+  if (row.featured !== undefined) {
+    properties.Featured = { checkbox: row.featured }
+  }
+
+  await notion.pages.create({
+    parent: { database_id: databaseId },
+    properties: properties as Parameters<
+      typeof notion.pages.create
+    >[0]['properties']
+  })
+}
+
+/**
+ * Full replace: update schema, archive existing pages, create new ones
+ * from the given content rows.
+ */
+export async function replaceAllContent(rows: ContentRow[]): Promise<{
+  archived: number
+  created: number
+}> {
+  const { notion, databaseId } = getNotionClient()
+  console.log('Updating database schema...')
+  await updateDatabaseSchema(notion, databaseId)
+  console.log('Archiving existing pages...')
+  const archived = await clearExistingPages(notion, databaseId)
+  console.log(`Archived ${archived} pages.`)
+  console.log('Creating new pages...')
+  for (const row of rows) {
+    console.log(`  ${row.section}: ${row.title}`)
+    await createPage(notion, databaseId, row)
+  }
+  return { archived, created: rows.length }
+}

--- a/scripts/lib/parse-resume-tex.ts
+++ b/scripts/lib/parse-resume-tex.ts
@@ -1,0 +1,510 @@
+/**
+ * Minimal LaTeX parser for the resume template used in
+ * github.com/smallchungus/WillChen_Resume03_09_DE.
+ *
+ * Produces ContentRow entries matching the Notion seed shape used by
+ * setup-notion-database.ts. Relies on the template's fixed commands
+ * (\resumeSubheading, \resumeItem, \resumeProjectHeading) rather than
+ * trying to parse arbitrary LaTeX. If the template changes
+ * structurally, this parser needs to be updated.
+ */
+
+export type ContentSection =
+  | 'hero'
+  | 'skills'
+  | 'projects'
+  | 'experience'
+  | 'education'
+
+export interface ContentRow {
+  title: string
+  section: ContentSection
+  order: number
+  description?: string
+  tags?: string[]
+  url?: string
+  duration?: string
+  impact?: string
+  company?: string
+  status?: string
+  featured?: boolean
+}
+
+/**
+ * Curated list of tech / tool names we'll recognize as tags when they
+ * appear bolded in experience or project descriptions.
+ *
+ * Keeps tag extraction predictable. Anything not on this list (e.g. a
+ * bolded metric like "50+" or an adjective phrase) won't become a tag.
+ */
+const KNOWN_TAGS = [
+  'Python',
+  'Go',
+  'SQL',
+  'JavaScript',
+  'TypeScript',
+  'Java',
+  'Spring Boot',
+  'Node.js',
+  'React',
+  'Redux',
+  'Tailwind CSS',
+  'Vite',
+  'HTML/CSS',
+  'PostgreSQL',
+  'Redis',
+  'Amazon Redshift',
+  'Redshift',
+  'MongoDB',
+  'AWS',
+  'AWS Glue',
+  'AWS Lambda',
+  'Step Functions',
+  'S3',
+  'Lambda',
+  'Glue',
+  'Docker',
+  'Kubernetes',
+  'GitHub Actions',
+  'Datadog',
+  'Tableau',
+  'Bash',
+  'scikit-learn',
+  'Machine Learning',
+  'Mass Spectrometry',
+  'Reinforcement Learning',
+  'PhysX',
+  'Simulation',
+  'AMR',
+  'Solidity',
+  'Hardhat',
+  'Next.js',
+  'ethers.js',
+  'Kafka',
+  'Apache Kafka',
+  'Bloomberg',
+  'Reuters',
+  'Grafana',
+  'Azure DevOps',
+  'CI/CD',
+  'ETL'
+]
+
+// ---------------------------------------------------------------------------
+// Low-level helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the content of a balanced `{...}` group starting at `startIdx`.
+ * `str[startIdx]` must be `{`. Respects `\{` and `\}` escapes.
+ * Returns { content, end } where `end` is the index of the closing `}`.
+ */
+function extractBalancedBraces(
+  str: string,
+  startIdx: number
+): { content: string; end: number } | null {
+  if (str[startIdx] !== '{') return null
+  let depth = 1
+  let i = startIdx + 1
+  while (i < str.length && depth > 0) {
+    const ch = str[i]
+    if (ch === '\\') {
+      // Skip any escaped character (\{, \}, \%, \\, etc.)
+      i += 2
+      continue
+    }
+    if (ch === '{') depth++
+    else if (ch === '}') depth--
+    if (depth === 0) return { content: str.substring(startIdx + 1, i), end: i }
+    i++
+  }
+  return null
+}
+
+/** Skip whitespace starting at `idx`, return the first non-whitespace index. */
+function skipWhitespace(str: string, idx: number): number {
+  while (idx < str.length && /\s/.test(str[idx])) idx++
+  return idx
+}
+
+/**
+ * Strip the LaTeX formatting commands we know about and normalize
+ * escape sequences and whitespace.
+ */
+function cleanLatex(text: string): string {
+  return text
+    // Formatting wrappers: \textbf{X}, \textit{X}, \emph{X}, \underline{X}
+    // Iterate because of possible nested wrappers.
+    .replace(/\\(textbf|textit|emph|underline)\{([^{}]*)\}/g, '$2')
+    .replace(/\\(textbf|textit|emph|underline)\{([^{}]*)\}/g, '$2')
+    // \href{url}{text} — keep the visible text
+    .replace(/\\href\{[^{}]*\}\{([^{}]*)\}/g, '$1')
+    // Common escape sequences
+    .replace(/\\textasciitilde/g, '~')
+    .replace(/\\&/g, '&')
+    .replace(/\\%/g, '%')
+    .replace(/\\\$/g, '$')
+    .replace(/\\_/g, '_')
+    .replace(/\\#/g, '#')
+    // LaTeX dashes: `--` is an en-dash, `---` em-dash. Normalize to hyphen.
+    .replace(/---/g, '-')
+    .replace(/--/g, '-')
+    // LaTeX line breaks and stretch
+    .replace(/\\\\/g, ' ')
+    .replace(/\$\|\$/g, '|')
+    .replace(/\$/g, '')
+    // Collapse whitespace
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/** Extract a whole `\section{Name}` block's body up to the next section. */
+function getSection(tex: string, name: string): string | null {
+  const sectionRe = new RegExp(`\\\\section\\{\\s*${name}\\s*\\}`, 'i')
+  const match = sectionRe.exec(tex)
+  if (!match) return null
+  const start = match.index + match[0].length
+  const rest = tex.substring(start)
+  const nextSection = /\\section\{/.exec(rest)
+  const endDoc = /\\end\{document\}/.exec(rest)
+  let endOffset = rest.length
+  if (nextSection) endOffset = Math.min(endOffset, nextSection.index)
+  if (endDoc) endOffset = Math.min(endOffset, endDoc.index)
+  return rest.substring(0, endOffset)
+}
+
+// ---------------------------------------------------------------------------
+// Command-level parsers
+// ---------------------------------------------------------------------------
+
+interface ParsedSubheading {
+  args: string[] // length 4: [institution/company, location, degree/role, duration]
+  items: Array<{ label: string; text: string }>
+  /** Raw body between this subheading and the next — used for tag extraction. */
+  rawBody: string
+}
+
+function parseSubheadings(sectionBody: string): ParsedSubheading[] {
+  const results: ParsedSubheading[] = []
+  const commandRe = /\\resumeSubheading\b/g
+  const matches = Array.from(sectionBody.matchAll(commandRe))
+
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i]
+    const cmdEnd = (match.index ?? 0) + match[0].length
+    let argPos = cmdEnd
+    const args: string[] = []
+
+    for (let a = 0; a < 4; a++) {
+      argPos = skipWhitespace(sectionBody, argPos)
+      const extract = extractBalancedBraces(sectionBody, argPos)
+      if (!extract) break
+      args.push(cleanLatex(extract.content))
+      argPos = extract.end + 1
+    }
+    if (args.length < 4) continue
+
+    const nextStart =
+      i + 1 < matches.length ? matches[i + 1].index! : sectionBody.length
+    const blockBody = sectionBody.substring(argPos, nextStart)
+    const items = parseItems(blockBody)
+
+    results.push({ args, items, rawBody: blockBody })
+  }
+  return results
+}
+
+function parseItems(body: string): Array<{ label: string; text: string }> {
+  const items: Array<{ label: string; text: string }> = []
+  // Match \resumeItem but NOT \resumeItemListStart/End.
+  const itemRe = /\\resumeItem(?!ListStart|ListEnd)\b/g
+  for (const match of body.matchAll(itemRe)) {
+    let argPos = (match.index ?? 0) + match[0].length
+    argPos = skipWhitespace(body, argPos)
+    const labelExtract = extractBalancedBraces(body, argPos)
+    if (!labelExtract) continue
+    argPos = skipWhitespace(body, labelExtract.end + 1)
+    const textExtract = extractBalancedBraces(body, argPos)
+    if (!textExtract) continue
+    items.push({
+      label: cleanLatex(labelExtract.content),
+      text: cleanLatex(textExtract.content)
+    })
+  }
+  return items
+}
+
+interface ParsedProject {
+  title: string
+  techStack: string
+  items: Array<{ label: string; text: string }>
+  rawBody: string
+}
+
+function parseProjects(sectionBody: string): ParsedProject[] {
+  const results: ParsedProject[] = []
+  const headingRe = /\\resumeProjectHeading\b/g
+  const matches = Array.from(sectionBody.matchAll(headingRe))
+
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i]
+    const cmdEnd = (match.index ?? 0) + match[0].length
+    let argPos = skipWhitespace(sectionBody, cmdEnd)
+
+    const firstArg = extractBalancedBraces(sectionBody, argPos)
+    if (!firstArg) continue
+    argPos = skipWhitespace(sectionBody, firstArg.end + 1)
+    const secondArg = extractBalancedBraces(sectionBody, argPos)
+    // Second arg might be empty `{}`, we just need to advance past it.
+    argPos = secondArg ? secondArg.end + 1 : argPos
+
+    // firstArg looks like: \textbf{Title} $|$ \emph{tech, stack, here}
+    const raw = firstArg.content
+    const titleMatch = /\\textbf\{([^{}]*)\}/.exec(raw)
+    const techMatch = /\\emph\{([^{}]*)\}/.exec(raw)
+    const title = titleMatch ? cleanLatex(titleMatch[1]) : cleanLatex(raw)
+    const techStack = techMatch ? cleanLatex(techMatch[1]) : ''
+
+    const nextStart =
+      i + 1 < matches.length ? matches[i + 1].index! : sectionBody.length
+    const blockBody = sectionBody.substring(argPos, nextStart)
+    const items = parseItems(blockBody)
+
+    results.push({ title, techStack, items, rawBody: blockBody })
+  }
+  return results
+}
+
+/**
+ * From a raw LaTeX block, return the subset of KNOWN_TAGS that appear
+ * bolded anywhere in the block. Preserves document order, dedupes.
+ */
+function extractTags(rawBody: string): string[] {
+  const boldMatches = Array.from(rawBody.matchAll(/\\textbf\{([^{}]*)\}/g))
+  const seen = new Set<string>()
+  const ordered: string[] = []
+  for (const match of boldMatches) {
+    const value = cleanLatex(match[1])
+    const hit = KNOWN_TAGS.find(
+      (t) => t === value || t.toLowerCase() === value.toLowerCase()
+    )
+    if (hit && !seen.has(hit)) {
+      seen.add(hit)
+      ordered.push(hit)
+    }
+  }
+  // If we captured both "Glue" and "AWS Glue", keep only the more specific one.
+  return ordered.filter(
+    (t) => !ordered.some((other) => other !== t && other.includes(t))
+  )
+}
+
+/**
+ * Split a comma-separated string, respecting parenthesis depth so that
+ * "AWS (Glue, Lambda), Docker" splits into ["AWS (Glue, Lambda)", "Docker"].
+ */
+function splitRespectingParens(str: string): string[] {
+  const out: string[] = []
+  let depth = 0
+  let cur = ''
+  for (const ch of str) {
+    if (ch === '(') depth++
+    else if (ch === ')') depth--
+    if (ch === ',' && depth === 0) {
+      if (cur.trim()) out.push(cur.trim())
+      cur = ''
+    } else {
+      cur += ch
+    }
+  }
+  if (cur.trim()) out.push(cur.trim())
+  return out
+}
+
+/**
+ * Parse the Technical Skills section. Template uses an `\item` with
+ * multiple `\textbf{category}{: a, b, c}` lines separated by `\\`.
+ *
+ * Paren-annotated items like "AWS (Glue, Lambda, Step Functions)" are
+ * flattened: we emit the base name and each inner item as separate tags.
+ */
+function parseSkills(
+  sectionBody: string
+): Array<{ title: string; tags: string[] }> {
+  const cleaned = sectionBody.replace(/\\small/g, '').replace(/\\item/g, '')
+  const categoryRe = /\\textbf\{([^{}]+)\}\{:\s*([^{}]+)\}/g
+  const results: Array<{ title: string; tags: string[] }> = []
+
+  for (const match of cleaned.matchAll(categoryRe)) {
+    const title = cleanLatex(match[1])
+    const list = cleanLatex(match[2])
+    const tags: string[] = []
+    for (const item of splitRespectingParens(list)) {
+      const paren = /^([^(]+)\(([^)]+)\)$/.exec(item)
+      if (!paren) {
+        tags.push(item.trim())
+        continue
+      }
+      const base = paren[1].trim()
+      const inner = paren[2]
+        .split(',')
+        .map((p) => p.trim())
+        .filter(Boolean)
+      if (base) tags.push(base)
+      for (const sub of inner) tags.push(sub)
+    }
+    results.push({ title, tags: tags.filter(Boolean) })
+  }
+  return results
+}
+
+/**
+ * Build a short "MS Analytics @ Georgia Tech"-style label from an
+ * education row, for use as a hero role.
+ */
+function shortEduLabel(row: ContentRow): string {
+  const degree = (row.title || '')
+    .replace(/Master of Science in /i, 'MS ')
+    .replace(/Master of Arts in /i, 'MA ')
+    .replace(/Bachelor of Arts in /i, 'BA ')
+    .replace(/Bachelor of Science in /i, 'BS ')
+  const school = (row.company || '')
+    .replace(/Georgia Institute of Technology/i, 'Georgia Tech')
+    .replace(/Arizona State University/i, 'ASU')
+    .replace(/Rutgers University/i, 'Rutgers')
+    .replace(/Massachusetts Institute of Technology/i, 'MIT')
+  return `${degree} @ ${school}`
+}
+
+// ---------------------------------------------------------------------------
+// Top-level
+// ---------------------------------------------------------------------------
+
+export function parseResumeTex(tex: string): ContentRow[] {
+  const rows: ContentRow[] = []
+
+  // Parse title line "\textbf{... Software Engineer $|$ Data Engineer}"
+  const roleHeaderMatch = /\\textbf\{\s*([^{}]*\$\|\$[^{}]*)\s*\}/.exec(tex)
+  const roleRaw = roleHeaderMatch ? cleanLatex(roleHeaderMatch[1]) : ''
+  const heroRoles = roleRaw
+    .split('|')
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  // EDUCATION
+  const eduBody = getSection(tex, 'Education')
+  if (eduBody) {
+    const subs = parseSubheadings(eduBody)
+    subs.forEach((s, i) => {
+      // args: [institution, location, degree, duration]
+      // Degree may embed GPA ("Bachelor of Arts in CS and Psychology, GPA: 3.44")
+      let degree = s.args[2]
+      let status = ''
+      const gpaMatch = /,?\s*GPA:?\s*([\d.]+)/i.exec(degree)
+      if (gpaMatch) {
+        status = `GPA ${gpaMatch[1]}`
+        degree = degree.replace(gpaMatch[0], '').trim().replace(/,$/, '').trim()
+      } else if (/Present/i.test(s.args[3])) {
+        status = 'Current Student'
+      }
+      rows.push({
+        title: degree,
+        section: 'education',
+        order: 40 + i,
+        company: s.args[0],
+        status,
+        duration: s.args[3]
+      })
+    })
+  }
+
+  // EXPERIENCE
+  const expBody = getSection(tex, 'Experience')
+  if (expBody) {
+    const subs = parseSubheadings(expBody)
+    subs.forEach((s, i) => {
+      // args: [company, location, title, duration]
+      const description = s.items.map((it) => it.text).join(' ')
+      rows.push({
+        title: s.args[2],
+        section: 'experience',
+        order: 30 + i,
+        company: s.args[0],
+        duration: s.args[3],
+        description,
+        tags: extractTags(s.rawBody)
+      })
+    })
+  }
+
+  // PROJECTS
+  const projBody = getSection(tex, 'Projects')
+  if (projBody) {
+    const projects = parseProjects(projBody)
+    projects.forEach((p, i) => {
+      // First item is the main description; remaining items join as impact.
+      const [first, ...rest] = p.items
+      const description = first ? first.text : ''
+      const impact = rest.map((it) => it.text).join(' ')
+      const techTags = p.techStack
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+      rows.push({
+        title: p.title,
+        section: 'projects',
+        order: 20 + i,
+        description,
+        tags: techTags.length > 0 ? techTags : extractTags(p.rawBody),
+        impact,
+        featured: true,
+        url: 'https://github.com/smallchungus'
+      })
+    })
+
+    // Add the portfolio itself as a second project (not in resume).
+    rows.push({
+      title: 'Portfolio Website',
+      section: 'projects',
+      order: 20 + projects.length,
+      description:
+        'Modern, minimal portfolio with dark mode, Notion CMS integration, and 95+ Lighthouse score',
+      tags: ['React', 'TypeScript', 'Tailwind CSS', 'Vite'],
+      url: 'https://github.com/smallchungus/PortfolioWebsite',
+      impact: 'Built with TDD practices and Notion-powered content management',
+      featured: true
+    })
+  }
+
+  // SKILLS
+  const skillsBody = getSection(tex, 'Technical Skills')
+  if (skillsBody) {
+    const categories = parseSkills(skillsBody)
+    categories.forEach((c, i) => {
+      rows.push({
+        title: c.title,
+        section: 'skills',
+        order: 10 + i,
+        tags: c.tags
+      })
+    })
+  }
+
+  // HERO — constructed last so we can derive the current-school label from education.
+  const firstEdu = rows.find(
+    (r) => r.section === 'education' && /Present/i.test(r.duration || '')
+  )
+  const eduLabel = firstEdu ? shortEduLabel(firstEdu) : ''
+
+  rows.unshift({
+    title: 'Hero',
+    section: 'hero',
+    order: 1,
+    description: 'Python, Go, SQL, AWS, Docker, Kubernetes',
+    tags: eduLabel ? [...heroRoles, eduLabel] : heroRoles,
+    impact:
+      'Building production-grade ETL pipelines and distributed systems. Passionate about data infrastructure, cloud-native tooling, and reliable engineering at scale.'
+  })
+
+  return rows
+}

--- a/scripts/setup-notion-database.ts
+++ b/scripts/setup-notion-database.ts
@@ -1,16 +1,17 @@
 /* eslint-disable no-console */
+/**
+ * Manual Notion seed script. Hardcoded content — use this for initial
+ * setup or when the resume repo isn't reachable. For ongoing sync,
+ * prefer sync-from-resume.ts which parses the live LaTeX source.
+ */
 import { config } from 'dotenv'
 config({ path: '.env.local' })
 
-import { Client } from '@notionhq/client'
-
-const NOTION_API_KEY = process.env.NOTION_API_KEY!
-const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID!
-
-const notion = new Client({ auth: NOTION_API_KEY })
+import { replaceAllContent } from './lib/notion-sync.js'
+import type { ContentRow } from './lib/parse-resume-tex.js'
 
 // Content to populate - Sourced from latest WillChen_Resume03_09_DE main.tex
-const CONTENT_ROWS = [
+const CONTENT_ROWS: ContentRow[] = [
   // Hero
   {
     title: 'Hero',
@@ -150,143 +151,12 @@ const CONTENT_ROWS = [
   }
 ]
 
-async function updateDatabaseSchema() {
-  console.log('Updating database schema...')
-
-  try {
-    await notion.databases.update({
-      database_id: NOTION_DATABASE_ID,
-      properties: {
-        Section: {
-          select: {
-            options: [
-              { name: 'siteConfig', color: 'gray' },
-              { name: 'contact', color: 'blue' },
-              { name: 'skills', color: 'green' },
-              { name: 'projects', color: 'purple' },
-              { name: 'experience', color: 'orange' },
-              { name: 'education', color: 'yellow' },
-              { name: 'hero', color: 'red' }
-            ]
-          }
-        },
-        Order: { number: {} },
-        Description: { rich_text: {} },
-        Tags: { multi_select: { options: [] } },
-        URL: { url: {} },
-        Duration: { rich_text: {} },
-        Impact: { rich_text: {} },
-        Company: { rich_text: {} },
-        Status: { rich_text: {} },
-        Featured: { checkbox: {} }
-      }
-    })
-    console.log('Database schema updated!')
-  } catch (error) {
-    console.error('Error updating schema:', error)
-    throw error
-  }
-}
-
-async function clearExistingPages() {
-  console.log('Clearing existing pages...')
-
-  const response = await notion.databases.query({
-    database_id: NOTION_DATABASE_ID
-  })
-
-  for (const page of response.results) {
-    await notion.pages.update({
-      page_id: page.id,
-      archived: true
-    })
-  }
-
-  console.log(`Archived ${response.results.length} existing pages`)
-}
-
-async function createPage(row: typeof CONTENT_ROWS[0]) {
-  const properties: Record<string, unknown> = {
-    Name: {
-      title: [{ text: { content: row.title } }]
-    },
-    Section: {
-      select: { name: row.section }
-    },
-    Order: {
-      number: row.order
-    }
-  }
-
-  if (row.description) {
-    properties.Description = {
-      rich_text: [{ text: { content: row.description } }]
-    }
-  }
-
-  if (row.tags && row.tags.length > 0) {
-    properties.Tags = {
-      multi_select: row.tags.map(tag => ({ name: tag }))
-    }
-  }
-
-  if (row.url) {
-    properties.URL = { url: row.url }
-  }
-
-  if (row.duration) {
-    properties.Duration = {
-      rich_text: [{ text: { content: row.duration } }]
-    }
-  }
-
-  if (row.impact) {
-    properties.Impact = {
-      rich_text: [{ text: { content: row.impact } }]
-    }
-  }
-
-  if (row.company) {
-    properties.Company = {
-      rich_text: [{ text: { content: row.company } }]
-    }
-  }
-
-  if (row.status) {
-    properties.Status = {
-      rich_text: [{ text: { content: row.status } }]
-    }
-  }
-
-  if (row.featured !== undefined) {
-    properties.Featured = { checkbox: row.featured }
-  }
-
-  await notion.pages.create({
-    parent: { database_id: NOTION_DATABASE_ID },
-    properties: properties as Parameters<typeof notion.pages.create>[0]['properties']
-  })
-}
-
-async function populateDatabase() {
-  console.log('Populating database with content...')
-
-  for (const row of CONTENT_ROWS) {
-    console.log(`  Creating: ${row.title}`)
-    await createPage(row)
-  }
-
-  console.log(`Created ${CONTENT_ROWS.length} pages!`)
-}
-
 async function main() {
-  console.log('Setting up Notion database...\n')
-
-  await updateDatabaseSchema()
-  await clearExistingPages()
-  await populateDatabase()
-
-  console.log('\nDone! Your Notion database is now populated.')
+  console.log('Setting up Notion database from hardcoded seed...\n')
+  const result = await replaceAllContent(CONTENT_ROWS)
+  console.log(
+    `\nDone! Archived ${result.archived} old pages, created ${result.created} new pages.`
+  )
   console.log('Run `npm run prebuild` to fetch the content.')
 }
 

--- a/scripts/sync-from-resume.ts
+++ b/scripts/sync-from-resume.ts
@@ -1,0 +1,42 @@
+/* eslint-disable no-console */
+/**
+ * Auto-sync entry point: fetch the latest main.tex from the resume repo,
+ * parse it, and replace the Notion database contents. Runs in CI on a
+ * schedule and on repository_dispatch events.
+ *
+ * Env vars required:
+ *   NOTION_API_KEY
+ *   NOTION_DATABASE_ID
+ *
+ * Optional:
+ *   RESUME_TEX_URL (override the default raw URL, handy for testing)
+ */
+import { config } from 'dotenv'
+config({ path: '.env.local' })
+config({ path: '.env' })
+
+import { parseResumeTex } from './lib/parse-resume-tex.js'
+import { replaceAllContent } from './lib/notion-sync.js'
+
+const DEFAULT_URL =
+  'https://raw.githubusercontent.com/smallchungus/WillChen_Resume03_09_DE/main/main.tex'
+
+async function main() {
+  const url = process.env.RESUME_TEX_URL || DEFAULT_URL
+  console.log(`Fetching ${url}`)
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`Fetch failed: ${res.status} ${res.statusText}`)
+  const tex = await res.text()
+  console.log(`Fetched ${tex.length} bytes`)
+
+  const rows = parseResumeTex(tex)
+  console.log(`Parsed ${rows.length} content rows`)
+
+  const { archived, created } = await replaceAllContent(rows)
+  console.log(`Done. Archived ${archived}, created ${created}.`)
+}
+
+main().catch((err) => {
+  console.error('Sync failed:', err)
+  process.exit(1)
+})

--- a/src/components/sections/About/About.test.tsx
+++ b/src/components/sections/About/About.test.tsx
@@ -276,10 +276,10 @@ describe('About Section', () => {
       const summary = screen.getByTestId('professional-summary')
       const text = summary.textContent || ''
 
-      // Should mention key DE narrative points
-      expect(text).toMatch(/data engineer/i)
-      expect(text).toMatch(/Viatrie/i)
-      expect(text).toMatch(/Georgia Tech/i)
+      // Summary is now data-driven from heroContent.description — assert
+      // against themes rather than specific company/school names, since those
+      // live in the experience and education cards.
+      expect(text).toMatch(/ETL pipelines|distributed systems|data infrastructure/i)
     })
 
     it('shows organized technical skills', () => {
@@ -336,8 +336,7 @@ describe('About Section', () => {
       render(<About />)
 
       // Current experience: Viatrie Data Engineer + Rutgers Lab RA + Isaac Lab (NVIDIA).
-      // Viatrie also appears in the professional summary, so expect at least 2.
-      expect(screen.getAllByText(/Viatrie/i).length).toBeGreaterThanOrEqual(2)
+      expect(screen.getAllByText(/Viatrie/i).length).toBeGreaterThanOrEqual(1)
       expect(screen.getAllByText(/Rutgers Chlamydia Lab/i).length).toBeGreaterThanOrEqual(1)
       expect(screen.getAllByText(/Isaac Lab/i).length).toBeGreaterThanOrEqual(1)
     })

--- a/src/components/sections/About/About.tsx
+++ b/src/components/sections/About/About.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '../../ui/Badge'
 import { Reveal } from '../../ui/Reveal'
-import { skills, experience, education } from '@/content'
+import { skills, experience, education, heroContent } from '@/content'
 
 export const About = () => {
   // Convert skills object to array format for rendering
@@ -32,10 +32,7 @@ export const About = () => {
             className="text-lg text-gray-600 dark:text-gray-300 leading-relaxed max-w-4xl"
             data-testid="professional-summary"
           >
-            Data Engineer at Viatrie building production ETL pipelines on AWS for USDA federal contracts —
-            150+ pipelines, 200+ tables across 3 environments. Currently pursuing MS Analytics at Georgia
-            Tech. Open-source contributor to NVIDIA Isaac Lab and research software engineer at Rutgers
-            Chlamydia Lab. U.S. Citizen with Public Trust Suitability.
+            {heroContent.description}
           </p>
 
           {/* Education */}


### PR DESCRIPTION
Closes the "edit resume → run seed script → commit" loop. GitHub Actions parses main.tex and updates Notion whenever it runs.

## Architecture

```
resume repo (main.tex push)
     │
     ├─ [optional] repository_dispatch → portfolio Action runs immediately
     │
     └─ [fallback] portfolio cron runs every 30 min
                                │
                                ▼
                    sync-from-resume.ts
                        │
                        ├─ fetches raw main.tex from GitHub
                        ├─ parses with lib/parse-resume-tex.ts
                        ├─ calls replaceAllContent() (archives + creates)
                        │
                        └─ [optional] POSTs to Vercel deploy hook
                                     → site redeploys with fresh Notion
```

## What's in this PR

- `scripts/lib/parse-resume-tex.ts` — minimal LaTeX parser tailored to the template. Brace-balanced extraction, known-tag filter, paren-aware splitter, substring dedupe.
- `scripts/lib/notion-sync.ts` — shared Notion helpers extracted from `setup-notion-database.ts`.
- `scripts/sync-from-resume.ts` — orchestrator: fetch → parse → replace.
- `scripts/setup-notion-database.ts` — refactored to use the shared lib; kept for manual/offline reseed.
- `.github/workflows/sync-resume.yml` — triggers: workflow_dispatch, repository_dispatch (type=resume-updated), and a 30-minute cron.
- `About.tsx` professional summary is now data-driven from `heroContent.description` so it can't drift from Notion.

## Required action from you

Add these secrets at [Settings → Secrets and variables → Actions](https://github.com/smallchungus/PortfolioWebsite/settings/secrets/actions):

- **`NOTION_API_KEY`** — same token in your `.env.local`
- **`NOTION_DATABASE_ID`** — same database ID in your `.env.local`

Until both are set, the workflow will fail. Nothing breaks on the site — it just won't auto-sync.

## Optional actions

- **`VERCEL_DEPLOY_HOOK_URL`** (secret) — create one at Vercel → Project Settings → Git → Deploy Hooks, paste the URL as a secret. With this set, the site redeploys automatically every time the sync detects new content. Without it, changes show up on the next code push.
- **Push-time trigger** — add a one-line workflow to the resume repo that fires `repository_dispatch` (type=resume-updated) on every push. Real-time sync instead of 30-min cron. I can draft this if you want it.

## Test plan

- [x] Parser tested manually against live main.tex — output matches the structured data shape
- [x] 132/132 tests pass
- [x] type-check passes
- [x] build passes
- [ ] After merge: add Notion secrets, trigger workflow manually from Actions tab, verify Notion DB repopulates correctly
- [ ] If you want instant-redeploy: add VERCEL_DEPLOY_HOOK_URL secret, re-run workflow, verify the site updates