### PR TITLE
feat(ui): render experience + project descriptions as bullet lists

### DIFF
--- a/scripts/lib/parse-resume-tex.ts
+++ b/scripts/lib/parse-resume-tex.ts
@@ -424,7 +424,11 @@ export function parseResumeTex(tex: string): ContentRow[] {
     const subs = parseSubheadings(expBody)
     subs.forEach((s, i) => {
       // args: [company, location, title, duration]
-      const description = s.items.map((it) => it.text).join(' ')
+      // Preserve bullet structure — each \resumeItem becomes a newline-separated
+      // entry like "Label: Text". The UI splits on newlines and renders <ul>.
+      const description = s.items
+        .map((it) => (it.label ? `${it.label}: ${it.text}` : it.text))
+        .join('\n')
       rows.push({
         title: s.args[2],
         section: 'experience',
@@ -442,10 +446,10 @@ export function parseResumeTex(tex: string): ContentRow[] {
   if (projBody) {
     const projects = parseProjects(projBody)
     projects.forEach((p, i) => {
-      // First item is the main description; remaining items join as impact.
-      const [first, ...rest] = p.items
-      const description = first ? first.text : ''
-      const impact = rest.map((it) => it.text).join(' ')
+      // All items as newline-separated bullets (same as experience).
+      const description = p.items
+        .map((it) => (it.label ? `${it.label}: ${it.text}` : it.text))
+        .join('\n')
       const techTags = p.techStack
         .split(',')
         .map((s) => s.trim())
@@ -456,7 +460,6 @@ export function parseResumeTex(tex: string): ContentRow[] {
         order: 20 + i,
         description,
         tags: techTags.length > 0 ? techTags : extractTags(p.rawBody),
-        impact,
         featured: true,
         url: 'https://github.com/smallchungus'
       })

--- a/src/components/sections/About/About.tsx
+++ b/src/components/sections/About/About.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '../../ui/Badge'
 import { Reveal } from '../../ui/Reveal'
+import { BulletedDescription } from '../../ui/BulletedDescription'
 import { skills, experience, education, heroContent } from '@/content'
 
 export const About = () => {
@@ -101,7 +102,11 @@ export const About = () => {
                   </div>
                   <span className="text-sm text-gray-500 dark:text-gray-400 font-mono">{exp.duration}</span>
                 </div>
-                <p className="text-gray-700 dark:text-gray-300 leading-relaxed">{exp.description}</p>
+                <BulletedDescription
+                  text={exp.description}
+                  className="text-gray-700 dark:text-gray-300 leading-relaxed"
+                  labelClassName="text-gray-900 dark:text-white"
+                />
               </div>
             ))}
           </div>

--- a/src/components/sections/Projects/Projects.tsx
+++ b/src/components/sections/Projects/Projects.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '../../ui/Badge'
 import { Reveal } from '../../ui/Reveal'
+import { BulletedDescription } from '../../ui/BulletedDescription'
 import { projects } from '@/content'
 
 export const Projects = () => {
@@ -36,12 +37,15 @@ export const Projects = () => {
             </h3>
 
             {/* Project Description */}
-            <p
-              className="text-gray-600 dark:text-gray-300 mb-4 leading-relaxed"
+            <div
+              className="mb-4 text-gray-600 dark:text-gray-300 leading-relaxed"
               data-testid={`project-description-${project.id}`}
             >
-              {project.description}
-            </p>
+              <BulletedDescription
+                text={project.description}
+                labelClassName="text-gray-900 dark:text-white"
+              />
+            </div>
 
             {/* Impact */}
             {project.impact && (

--- a/src/components/ui/BulletedDescription/BulletedDescription.tsx
+++ b/src/components/ui/BulletedDescription/BulletedDescription.tsx
@@ -1,0 +1,55 @@
+interface BulletedDescriptionProps {
+  text: string
+  className?: string
+  listClassName?: string
+  labelClassName?: string
+}
+
+/**
+ * Renders a newline-separated string as a bulleted list when there are
+ * multiple lines, or as a single paragraph otherwise.
+ *
+ * Each line can optionally use a "Label: text" shape — the label is bolded.
+ * This matches how our resume parser emits experience/project descriptions
+ * from `\resumeItem{label}{text}` commands.
+ */
+export const BulletedDescription = ({
+  text,
+  className = '',
+  listClassName = '',
+  labelClassName = ''
+}: BulletedDescriptionProps) => {
+  const lines = text
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+
+  if (lines.length <= 1) {
+    return <p className={className}>{text}</p>
+  }
+
+  return (
+    <ul className={`list-disc pl-5 space-y-2 ${listClassName} ${className}`.trim()}>
+      {lines.map((line, idx) => {
+        // Match "Label: rest" — label is at the start, followed by a colon
+        // within 40 chars (keeps it a short tl;dr-style prefix, not a colon
+        // inside a sentence).
+        const colonIdx = line.indexOf(':')
+        const hasLabel = colonIdx > 0 && colonIdx < 40
+        if (hasLabel) {
+          const label = line.slice(0, colonIdx)
+          const rest = line.slice(colonIdx + 1).trim()
+          return (
+            <li key={idx}>
+              <span className={`font-semibold ${labelClassName}`.trim()}>
+                {label}:
+              </span>{' '}
+              {rest}
+            </li>
+          )
+        }
+        return <li key={idx}>{line}</li>
+      })}
+    </ul>
+  )
+}

--- a/src/components/ui/BulletedDescription/index.ts
+++ b/src/components/ui/BulletedDescription/index.ts
@@ -1,0 +1,1 @@
+export { BulletedDescription } from './BulletedDescription'


### PR DESCRIPTION
## Problem
Experience cards and project cards on willchennn.com render as wall-of-text paragraphs, even though the resume explicitly has bullets. The previous parser joined \`\\resumeItem\` entries with spaces, collapsing structure.

## Fix
- **Parser** (\`scripts/lib/parse-resume-tex.ts\`): join items with \`\\n\` instead of \` \`, prefix each with its label (\`Pipeline Platform: Shipped 50+ ...\`)
- **New** \`BulletedDescription\` component: splits on newlines, renders as \`<ul><li>\` when there are multiple lines (with bolded labels), falls back to plain \`<p>\` when there's only one
- **About.tsx** experience cards and **Projects.tsx** project cards use the new component

## Backward compat
Single-paragraph descriptions still render fine as \`<p>\` — so existing Notion rows with flat-paragraph content (pre-sync) don't visually regress. After the next 30-min cron pushes new parser output to Notion, all existing multi-bullet items render as lists.

## Test plan
- [x] 132/132 tests pass
- [x] type-check passes
- [x] build passes (+400B CSS for list-disc utility, +200B JS for the component)
- [ ] After merge: trigger the sync-resume workflow manually to force-push bullet format to Notion; verify the Experience cards and Distributed Task Queue card render as lists on preview deploy