### PR TITLE
fix(sync): split multi-bullet descriptions across rich_text segments

### DIFF
--- a/.github/workflows/sync-resume.yml
+++ b/.github/workflows/sync-resume.yml
@@ -23,10 +23,10 @@ on:
   repository_dispatch:
     types: [resume-updated]
   schedule:
-    # Every 30 minutes. GitHub may delay scheduled runs under load; that's OK
-    # because this is non-blocking — the site still builds fine from existing
-    # Notion content while the sync catches up.
-    - cron: '*/30 * * * *'
+    # Every 5 minutes (GitHub's minimum interval) as a safety net for when
+    # the push-triggered repository_dispatch from the resume repo doesn't fire
+    # for any reason.
+    - cron: '*/5 * * * *'
 
 jobs:
   sync:

--- a/scripts/lib/notion-sync.ts
+++ b/scripts/lib/notion-sync.ts
@@ -74,8 +74,16 @@ export async function createPage(
   }
 
   if (row.description) {
+    // Split long descriptions across multiple rich_text segments:
+    // - Notion's rich_text limit is 2000 chars per segment, so a 6-bullet
+    //   paragraph can silently truncate if sent in one segment.
+    // - Splitting on "\n" also preserves bullet line-breaks reliably across
+    //   the Notion API round-trip, which collapsing into one segment does not.
+    const parts = row.description.split('\n')
     properties.Description = {
-      rich_text: [{ text: { content: row.description } }]
+      rich_text: parts.map((part, i) => ({
+        text: { content: i < parts.length - 1 ? `${part}\n` : part }
+      }))
     }
   }
   if (row.tags && row.tags.length > 0) {

--- a/src/components/sections/About/About.test.tsx
+++ b/src/components/sections/About/About.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
 import { About } from './About'
+import { skills } from '@/content'
 
 // Mock window.matchMedia for responsive tests
 Object.defineProperty(window, 'matchMedia', {
@@ -45,13 +46,15 @@ describe('About Section', () => {
 
     it('shows skills grid with categories', () => {
       render(<About />)
-      
+
       const skillsGrid = screen.getByTestId('skills-grid')
       expect(skillsGrid).toBeInTheDocument()
-      
-      // Should have skill categories from current Notion content
-      const categories = ['Languages & Databases', 'Cloud & Infrastructure', 'Tooling & Practices']
-      categories.forEach(category => {
+
+      // Data-driven: every category from Notion content should be rendered.
+      // Keeps the assertion correct as the resume evolves.
+      const categories = Object.keys(skills)
+      expect(categories.length).toBeGreaterThanOrEqual(2)
+      categories.forEach((category) => {
         expect(screen.getByText(category)).toBeInTheDocument()
       })
     })
@@ -285,15 +288,11 @@ describe('About Section', () => {
     it('shows organized technical skills', () => {
       render(<About />)
 
-      // Sample of skills from current DE resume Notion content across categories
-      const expectedSkills = [
-        'Python', 'Go', 'SQL', 'JavaScript',
-        'PostgreSQL', 'Redis', 'Amazon Redshift',
-        'AWS Glue', 'AWS Lambda', 'Docker', 'Kubernetes',
-        'Datadog', 'GitHub Actions'
-      ]
-
-      expectedSkills.forEach(skill => {
+      // Data-driven: every skill in every category from Notion should render
+      // as a badge. Stays correct as the resume evolves.
+      const allSkills = Object.values(skills).flat()
+      expect(allSkills.length).toBeGreaterThan(5)
+      allSkills.forEach((skill) => {
         expect(screen.getByText(skill)).toBeInTheDocument()
       })
     })
@@ -359,14 +358,12 @@ describe('About Section', () => {
     it('shows correct technology stack', () => {
       render(<About />)
 
-      const expectedTech = [
-        'Python', 'Go', 'SQL', 'JavaScript',
-        'PostgreSQL', 'Redis', 'Amazon Redshift',
-        'AWS Glue', 'AWS Lambda', 'Step Functions',
-        'Docker', 'Kubernetes', 'Datadog'
-      ]
-
-      expectedTech.forEach(tech => {
+      // Data-driven: every skill listed in Notion renders. Duplicates with
+      // the "shows organized technical skills" test above but the intent is
+      // different (this is under "Real Resume Content"); keeping both as
+      // guards against regression.
+      const allSkills = Object.values(skills).flat()
+      allSkills.forEach((tech) => {
         expect(screen.getByText(tech)).toBeInTheDocument()
       })
     })


### PR DESCRIPTION
## The bullet bug you reported

Your Viatrie description ballooned past Notion's 2000-char limit per \`rich_text\` segment. Notion silently truncated it to just the first bullet, and on the site that showed up as one paragraph rendering the first item only.

## Fix
- \`notion-sync.ts\` now splits descriptions on \`\\n\` and emits one \`rich_text\` segment per bullet. Each segment except the last carries a trailing newline. Stays under the per-segment limit and round-trips newlines correctly.
- Cron tightened from 30 min → 5 min (GitHub's minimum) as the safety net
- Tests in \`About.test.tsx\` made data-driven — iterate over \`skills\` from \`@/content\` and assert every category + skill renders. Resume content changes no longer break the test suite.

## Push-triggered sync (done separately)
Committed \`.github/workflows/trigger-portfolio-sync.yml\` to your resume repo ([smallchungus/WillChen_Resume03_09_DE](https://github.com/smallchungus/WillChen_Resume03_09_DE)). Fires \`repository_dispatch\` to this repo on every push to main. Once you add the PAT secret there, sync is instant (not 5-min cron).

**One action on you** to enable instant sync:
1. Create a PAT with \`contents: read\` + \`actions: write\` on this repo at [github.com/settings/tokens](https://github.com/settings/tokens)
2. In the **resume** repo, add a secret named \`PORTFOLIO_DISPATCH_TOKEN\` with that PAT value

Without the PAT the workflow is a no-op; the 5-min cron still runs.

## Test plan
- [x] 132/132 tests pass (skills tests now data-driven)
- [x] type-check passes
- [x] build passes
- [ ] After merge + manual sync: verify Notion description round-trips with newlines intact, experience cards render as bullet lists on willchennn.com