### PR TITLE
fix(projects): unify project card styling, fold impact into description

### DIFF
--- a/scripts/lib/parse-resume-tex.ts
+++ b/scripts/lib/parse-resume-tex.ts
@@ -471,10 +471,9 @@ export function parseResumeTex(tex: string): ContentRow[] {
       section: 'projects',
       order: 20 + projects.length,
       description:
-        'Modern, minimal portfolio with dark mode, Notion CMS integration, and 95+ Lighthouse score',
+        'Modern, minimal portfolio with dark mode, Notion CMS integration, and 95+ Lighthouse score. Built with TDD practices and Notion-powered content management.',
       tags: ['React', 'TypeScript', 'Tailwind CSS', 'Vite'],
       url: 'https://github.com/smallchungus/PortfolioWebsite',
-      impact: 'Built with TDD practices and Notion-powered content management',
       featured: true
     })
   }

--- a/scripts/setup-notion-database.ts
+++ b/scripts/setup-notion-database.ts
@@ -85,10 +85,9 @@ const CONTENT_ROWS: ContentRow[] = [
     section: 'projects',
     order: 21,
     description:
-      'Modern, minimal portfolio with dark mode, Notion CMS integration, and 95+ Lighthouse score',
+      'Modern, minimal portfolio with dark mode, Notion CMS integration, and 95+ Lighthouse score. Built with TDD practices and Notion-powered content management.',
     tags: ['React', 'TypeScript', 'Tailwind CSS', 'Vite'],
     url: 'https://github.com/smallchungus/PortfolioWebsite',
-    impact: 'Built with TDD practices and Notion-powered content management',
     featured: true
   },
   // Experience

--- a/src/components/sections/Projects/Projects.test.tsx
+++ b/src/components/sections/Projects/Projects.test.tsx
@@ -354,11 +354,15 @@ describe('Projects Section', () => {
       })
     })
 
-    it('applies dark mode to impact text', () => {
+    it('applies dark mode to descriptions (impact merged in)', () => {
       render(<Projects />)
 
-      const impactElement = screen.getByText(/Built with TDD practices/i)
-      expect(impactElement).toHaveClass('text-gray-500', 'dark:text-gray-400')
+      // Impact text is now part of the description instead of a separate block,
+      // so it inherits description styling (text-gray-600, dark:text-gray-300).
+      const portfolioDescription = screen
+        .getAllByText(/Built with TDD practices/i)[0]
+        .closest('[data-testid^="project-description-"]')
+      expect(portfolioDescription).toHaveClass('text-gray-600', 'dark:text-gray-300')
     })
 
     it('applies dark mode to action buttons', () => {

--- a/src/components/sections/Projects/Projects.tsx
+++ b/src/components/sections/Projects/Projects.tsx
@@ -38,7 +38,7 @@ export const Projects = () => {
 
             {/* Project Description */}
             <div
-              className="mb-4 text-gray-600 dark:text-gray-300 leading-relaxed"
+              className="mb-6 text-gray-600 dark:text-gray-300 leading-relaxed"
               data-testid={`project-description-${project.id}`}
             >
               <BulletedDescription
@@ -46,13 +46,6 @@ export const Projects = () => {
                 labelClassName="text-gray-900 dark:text-white"
               />
             </div>
-
-            {/* Impact */}
-            {project.impact && (
-              <p className="text-sm text-gray-500 dark:text-gray-400 mb-6 font-medium">
-                {project.impact}
-              </p>
-            )}
 
             {/* Tech Stack */}
             <div

--- a/src/content/fallback-content.json
+++ b/src/content/fallback-content.json
@@ -59,9 +59,8 @@
     {
       "id": "de-portfolio-website",
       "title": "Portfolio Website",
-      "description": "Modern, minimal portfolio with dark mode, Notion CMS integration, and 95+ Lighthouse score",
+      "description": "Modern, minimal portfolio with dark mode, Notion CMS integration, and 95+ Lighthouse score. Built with TDD practices and Notion-powered content management.",
       "technologies": ["React", "TypeScript", "Tailwind CSS", "Vite"],
-      "impact": "Built with TDD practices and Notion-powered content management",
       "links": {
         "github": "https://github.com/smallchungus/PortfolioWebsite"
       },


### PR DESCRIPTION
You said: 'make these the same font and font size please'.

The Distributed Task Queue card was rendering the description in one style and the impact field in a separate, smaller, different-color block (\`text-sm text-gray-500 font-medium\`). Two paragraphs, two fonts.

## Fix
- Removed the separate impact \`<p>\` render in Projects.tsx
- Portfolio Website's impact text is folded into its description so nothing's lost
- Distributed Task Queue and resume-parsed projects already had impact unset, so they just lose the orphan styled paragraph
- Same change applied to scripts/lib/parse-resume-tex.ts, scripts/setup-notion-database.ts, fallback-content.json, and the dark-mode test
- Live Notion already updated by manual sync run before this commit

## Result
- DTQ card: 3 bullet items via \`BulletedDescription\`, one consistent font + size
- Portfolio Website card: one paragraph, same font + size
- All other project cards: same treatment

132/132 tests pass.